### PR TITLE
Fetch dependencies through the Bazel federation.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 workspace(name = "rules_java")
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,11 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 workspace(name = "rules_java")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/d0bb2efce669b28b1bf3c6db98cea38704ced82d.zip",
-    sha256 = "0c8646a871d25b62a6f2cdd7c21a3dc617a37701adea2a4e678394a084966e8c",
-    strip_prefix = "bazel_federation-d0bb2efce669b28b1bf3c6db98cea38704ced82d",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/ade5370cb2c8be9e88a2ba6a15037139ae409f9c.zip",
+    sha256 = "0239a8af3fe66d17464a3be706109c021df31c461df3c447995f25efb63a1b22",
+    strip_prefix = "bazel-federation-ade5370cb2c8be9e88a2ba6a15037139ae409f9c",
     type = "zip",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,18 +1,24 @@
 workspace(name = "rules_java")
 
-load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
-rules_java_dependencies()
-rules_java_toolchains()
+http_archive(
+    name = "bazel_federation",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/d0bb2efce669b28b1bf3c6db98cea38704ced82d.zip",
+    sha256 = "0c8646a871d25b62a6f2cdd7c21a3dc617a37701adea2a4e678394a084966e8c",
+    strip_prefix = "bazel_federation-d0bb2efce669b28b1bf3c6db98cea38704ced82d",
+    type = "zip",
+)
 
+load("@bazel_federation//:repositories.bzl", "rules_java_deps")
+rules_java_deps()
+
+load("@bazel_federation//setup:rules_java.bzl", "rules_java_setup")
+rules_java_setup()
 
 #
 # Dependencies for development of rules_java itself.
 #
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "rules_pkg",
-    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.1/rules_pkg-0.2.1.tar.gz",
-    sha256 = "04c1eab736f508e94c297455915b6371432cbc4106765b5252b444d1656db051",
-)
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-rules_pkg_dependencies()
+load("//:internal_deps.bzl", "rules_java_internal_deps")
+rules_java_internal_deps()
+
+load("//:internal_setup.bzl", "rules_java_internal_setup")
+rules_java_internal_setup()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,9 +3,9 @@ workspace(name = "rules_java")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/ade5370cb2c8be9e88a2ba6a15037139ae409f9c.zip",
-    sha256 = "0239a8af3fe66d17464a3be706109c021df31c461df3c447995f25efb63a1b22",
-    strip_prefix = "bazel-federation-ade5370cb2c8be9e88a2ba6a15037139ae409f9c",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/01dc3f937696174c9764e23978f9d2e7105fd855.zip",
+    sha256 = "64229f859bb0465fcdb654b31b3e547bbd5462005beaebbc09eb0ec735044cdd",
+    strip_prefix = "bazel-federation-01dc3f937696174c9764e23978f9d2e7105fd855",
     type = "zip",
 )
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -1,0 +1,4 @@
+load("@bazel_federation//:repositories.bzl", "rules_pkg")
+
+def rules_java_internal_deps():
+    rules_pkg()

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -1,4 +1,21 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dependencies that are needed for rules_java tests and tools."""
+
 load("@bazel_federation//:repositories.bzl", "rules_pkg")
 
 def rules_java_internal_deps():
+    """Fetches all required dependencies for rules_java tests and tools."""
     rules_pkg()

--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -1,0 +1,2 @@
+def rules_java_internal_setup():
+    pass  # placeholder for the federation

--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -1,2 +1,18 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Setup for rules_java tests and tools."""
+
 def rules_java_internal_setup():
     pass  # placeholder for the federation

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# WARNING: This file only exists for backwards-compatibility.
+# rules_java uses the Bazel federation, so please add any new dependencies to
+# rules_java_deps() in
+# https://github.com/bazelbuild/bazel-federation/blob/master/repositories.bzl
+# Java-only third party dependencies can be added to
+# https://github.com/bazelbuild/bazel-federation/blob/master/java_repositories.bzl
+# Ideally we'd remove anything in this file except for rules_java_toolchains(),
+# which is being invoked as part of the federation setup.
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 


### PR DESCRIPTION
As a result of this commit, rules_java now contains the required bzl files to be tested as part of the Bazel federation.