### PR TITLE
Do not load my deps through the federation method which knows my deps.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,12 @@ exports_files(["LICENSE"])
 filegroup(
     name = "distribution",
     srcs = glob([
+        "BUILD",
         "LICENSE",
+        "*.bzl",
     ]),
-    visibility = ["@//distro:__pkg__"],
+    visibility = [
+        "@//distro:__pkg__",
+        "@rules_java//distro:__pkg__",
+    ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,11 +9,19 @@ http_archive(
     type = "zip",
 )
 
-load("@bazel_federation//:repositories.bzl", "rules_java_deps")
-rules_java_deps()
+# Load the dependencies
+load("@bazel_federation//:repositories.bzl", "bazel_skylib")
+bazel_skylib()
 
-load("@bazel_federation//setup:rules_java.bzl", "rules_java_setup")
-rules_java_setup()
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+rules_java_dependencies()
+rules_java_toolchains()
+
+# Set up the toolchains we need
+# TODO(aiuto): Define a standard annotation scheme so that the federation
+# maintainers can easily extract this to find create rules_java_setup()
+load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
+rules_java_toolchains()
 
 #
 # Dependencies for development of rules_java itself.

--- a/java/BUILD
+++ b/java/BUILD
@@ -10,5 +10,6 @@ filegroup(
     ],
     visibility = [
         "@//distro:__pkg__",
+        "@rules_java//distro:__pkg__",
     ],
 )


### PR DESCRIPTION
That leads to impossible update loops

1. Revert to loading dependencies to the older method
2. Leave an example of loading skylib through the federation, and
   overriding what I might have had locally. This technique can be used
   incrementally to move a big deps set towards federation compatibility
3. Fix visibilty of things needed for packaging. The strange looking
   list of //X and @rules_java//X is because of the remap_main_repo bug.