### PR TITLE
Use latest Bazel federation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,9 +3,9 @@ workspace(name = "rules_java")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/01dc3f937696174c9764e23978f9d2e7105fd855.zip",
-    sha256 = "64229f859bb0465fcdb654b31b3e547bbd5462005beaebbc09eb0ec735044cdd",
-    strip_prefix = "bazel-federation-01dc3f937696174c9764e23978f9d2e7105fd855",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/f0e5eda7f0cbfe67f126ef4dacb18c89039b0506.zip", # 2019-09-30
+    sha256 = "33222ab7bcc430f1ff1db8788c2e0118b749319dd572476c4fd02322d7d15792",
+    strip_prefix = "bazel-federation-f0e5eda7f0cbfe67f126ef4dacb18c89039b0506",
     type = "zip",
 )
 


### PR DESCRIPTION
This version includes rules_pkg 0.2.4, which can be used to cut a new rules_java release.