### PR TITLE
Generate correct WORKSPACE stanza for releases

### DIFF
--- a/distro/BUILD
+++ b/distro/BUILD
@@ -27,4 +27,7 @@ print_rel_notes(
     outs = ["relnotes.txt"],
     repo = "rules_java",
     version = version,
+    setup_file = "java:repositories.bzl",
+    deps_method = "rules_java_dependencies",
+    toolchains_method = "rules_java_toolchains",
 )


### PR DESCRIPTION
The stanza now contains the correct load statement and function calls.

Tested via `bazel build //distro:relnotes && cat bazel-bin/distro/relnotes.txt`