### PR TITLE
stardoc: allow rules_java to be used with stardoc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -61,3 +61,4 @@ use_repo(toolchains, "local_jdk")
 
 # Dev dependencies
 bazel_dep(name = "rules_pkg", dev_dependency = True, version = "0.5.1")
+bazel_dep(name = "bazel_skylib", dev_dependency = True, version = "1.2.0")

--- a/java/BUILD
+++ b/java/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
@@ -6,4 +8,10 @@ filegroup(
     name = "srcs",
     srcs = glob(["**"]),
     visibility = ["@//:__pkg__"],
+)
+
+bzl_library(
+    name = "rules",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Without this bzl_library definition users of rules_java get into
weird state when generating docs with stardoc