### PR TITLE
Update JDK versions and address bzlmod changes

### DIFF
--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -160,10 +160,11 @@ def remote_jdk11_repos():
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
-        sha256 = "b8e8a63b79bc312aa90f3558edbea59e71495ef1a9c340e38900dd28a1c579f3",
-        strip_prefix = "zulu11.50.19-ca-jdk11.0.12-linux_x64",
+        sha256 = "e064b61d93304012351242bf0823c6a2e41d9e28add7ea7f05378b7243d34247",
+        strip_prefix = "zulu11.56.19-ca-jdk11.0.15-linux_x64",
         urls = [
-            "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-linux_x64.tar.gz",
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-linux_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-linux_x64.tar.gz",
         ],
         version = "11",
     )
@@ -175,10 +176,11 @@ def remote_jdk11_repos():
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
         ],
-        sha256 = "61254688067454d3ccf0ef25993b5dcab7b56c8129e53b73566c28a8dd4d48fb",
-        strip_prefix = "zulu11.50.19-ca-jdk11.0.12-linux_aarch64",
+        sha256 = "fc7c41a0005180d4ca471c90d01e049469e0614cf774566d4cf383caa29d1a97",
+        strip_prefix = "zulu11.56.19-ca-jdk11.0.15-linux_aarch64",
         urls = [
-            "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-linux_aarch64.tar.gz",
+            "https://mirror.bazel.build/cdn.azul.com/zulu-embedded/bin/zulu11.56.19-ca-jdk11.0.15-linux_aarch64.tar.gz",
+            "https://cdn.azul.com/zulu-embedded/bin/zulu11.56.19-ca-jdk11.0.15-linux_aarch64.tar.gz",
         ],
         version = "11",
     )
@@ -190,11 +192,11 @@ def remote_jdk11_repos():
             "@platforms//os:linux",
             "@platforms//cpu:ppc",
         ],
-        sha256 = "a417db0295b1f4b538ecbaf7c774f3a177fab9657a665940170936c0eca4e71a",
-        strip_prefix = "jdk-11.0.7+10",
+        sha256 = "a8fba686f6eb8ae1d1a9566821dbd5a85a1108b96ad857fdbac5c1e4649fc56f",
+        strip_prefix = "jdk-11.0.15+10",
         urls = [
-            "https://mirror.bazel.build/openjdk/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
-            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.7_10.tar.gz",
+            "https://mirror.bazel.build/github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.15_10.tar.gz",
+            "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.15_10.tar.gz",
         ],
         version = "11",
     )
@@ -206,11 +208,11 @@ def remote_jdk11_repos():
             "@platforms//os:linux",
             "@platforms//cpu:s390x",
         ],
-        sha256 = "d9b72e87a1d3ebc0c9552f72ae5eb150fffc0298a7cb841f1ce7bfc70dcd1059",
-        strip_prefix = "jdk-11.0.7+10",
+        sha256 = "a58fc0361966af0a5d5a31a2d8a208e3c9bb0f54f345596fd80b99ea9a39788b",
+        strip_prefix = "jdk-11.0.15+10",
         urls = [
-            "https://mirror.bazel.build/github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
-            "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.7_10.tar.gz",
+            "https://mirror.bazel.build/github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.15_10.tar.gz",
+            "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15+10/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.15_10.tar.gz",
         ],
         version = "11",
     )
@@ -222,10 +224,11 @@ def remote_jdk11_repos():
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
-        sha256 = "0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7",
-        strip_prefix = "zulu11.50.19-ca-jdk11.0.12-macosx_x64",
+        sha256 = "2614e5c5de8e989d4d81759de4c333aa5b867b17ab9ee78754309ba65c7f6f55",
+        strip_prefix = "zulu11.56.19-ca-jdk11.0.15-macosx_x64",
         urls = [
-            "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-macosx_x64.tar.gz",
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_x64.tar.gz",
         ],
         version = "11",
     )
@@ -237,11 +240,11 @@ def remote_jdk11_repos():
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
-        sha256 = "e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17",
+        sha256 = "6bb0d2c6e8a29dcd9c577bbb2986352ba12481a9549ac2c0bcfd00ed60e538d2",
         strip_prefix = "zulu11.50.19-ca-jdk11.0.12-macosx_aarch64",
         urls = [
-            "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-macosx_aarch64.tar.gz",
-            "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_aarch64.tar.gz",
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_aarch64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_aarch64.tar.gz",
         ],
         version = "11",
     )
@@ -253,10 +256,26 @@ def remote_jdk11_repos():
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
-        sha256 = "42ae65e75d615a3f06a674978e1fa85fdf078cad94e553fee3e779b2b42bb015",
-        strip_prefix = "zulu11.50.19-ca-jdk11.0.12-win_x64",
+        sha256 = "a106c77389a63b6bd963a087d5f01171bd32aa3ee7377ecef87531390dcb9050",
+        strip_prefix = "zulu11.56.19-ca-jdk11.0.15-win_x64",
         urls = [
-            "https://mirror.bazel.build/openjdk/azul-zulu11.50.19-ca-jdk11.0.12/zulu11.50.19-ca-jdk11.0.12-win_x64.zip",
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-win_x64.zip",
+            "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-win_x64.zip",
+        ],
+        version = "11",
+    )
+
+    maybe(
+        remote_java_repository,
+        name = "remotejdk11_win_arm64",
+        target_compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:arm64",
+        ],
+        sha256 = "b8a28e6e767d90acf793ea6f5bed0bb595ba0ba5ebdf8b99f395266161e53ec2",
+        strip_prefix = "jdk-11.0.13+8",
+        urls = [
+            "https://mirror.bazel.build/aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-aarch64.zip",
         ],
         version = "11",
     )
@@ -402,11 +421,11 @@ def remote_jdk17_repos():
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
-        sha256 = "37c4f8e48536cceae8c6c20250d6c385e176972532fd35759fa7d6015c965f56",
-        strip_prefix = "zulu17.28.13-ca-jdk17.0.0-linux_x64",
+        sha256 = "73d5c4bae20325ca41b606f7eae64669db3aac638c5b3ead4a975055846ad6de",
+        strip_prefix = "zulu17.32.13-ca-jdk17.0.2-linux_x64",
         urls = [
-            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux_x64.tar.gz",
-            "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux_x64.tar.gz",
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-linux_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-linux_x64.tar.gz",
         ],
         version = "17",
     )
@@ -418,11 +437,11 @@ def remote_jdk17_repos():
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
-        sha256 = "6029b1fe6853cecad22ab99ac0b3bb4fb8c903dd2edefa91c3abc89755bbd47d",
-        strip_prefix = "zulu17.28.13-ca-jdk17.0.0-macosx_x64",
+        sha256 = "89d04b2d99b05dcb25114178e65f6a1c5ca742e125cab0a63d87e7e42f3fcb80",
+        strip_prefix = "zulu17.32.13-ca-jdk17.0.2-macosx_x64",
         urls = [
-            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-macosx_x64.tar.gz",
-            "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-macosx_x64.tar.gz",
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-macosx_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-macosx_x64.tar.gz",
         ],
         version = "17",
     )
@@ -434,15 +453,14 @@ def remote_jdk17_repos():
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
-        sha256 = "6b17f01f767ee7abf4704149ca4d86423aab9b16b68697b7d36e9b616846a8b0",
-        strip_prefix = "zulu17.28.13-ca-jdk17.0.0-macosx_aarch64",
+        sha256 = "54247dde248ffbcd3c048675504b1c503b81daf2dc0d64a79e353c48d383c977",
+        strip_prefix = "zulu17.32.13-ca-jdk17.0.2-macosx_aarch64",
         urls = [
-            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-macosx_aarch64.tar.gz",
-            "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-macosx_aarch64.tar.gz",
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-macosx_aarch64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-macosx_aarch64.tar.gz",
         ],
         version = "17",
     )
-
     maybe(
         remote_java_repository,
         name = "remotejdk17_win",
@@ -450,11 +468,26 @@ def remote_jdk17_repos():
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
-        sha256 = "f4437011239f3f0031c794bb91c02a6350bc941d4196bdd19c9f157b491815a3",
-        strip_prefix = "zulu17.28.13-ca-jdk17.0.0-win_x64",
+        sha256 = "e965aa0ea7a0661a3446cf8f10ee00684b851f883b803315289f26b4aa907fdb",
+        strip_prefix = "zulu17.32.13-ca-jdk17.0.2-win_x64",
         urls = [
-            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-win_x64.zip",
-            "https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-win_x64.zip",
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-win_x64.zip",
+            "https://cdn.azul.com/zulu/bin/zulu17.32.13-ca-jdk17.0.2-win_x64.zip",
+        ],
+        version = "17",
+    )
+    maybe(
+        remote_java_repository,
+        name = "remotejdk17_win_arm64",
+        target_compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:arm64",
+        ],
+        sha256 = "811d7e7591bac4f081dfb00ba6bd15b6fc5969e1f89f0f327ef75147027c3877",
+        strip_prefix = "zulu17.30.15-ca-jdk17.0.1-win_aarch64",
+        urls = [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.30.15-ca-jdk17.0.1-win_aarch64.zip",
+            "https://cdn.azul.com/zulu/bin/zulu17.30.15-ca-jdk17.0.1-win_aarch64.zip",
         ],
         version = "17",
     )

--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -58,10 +58,10 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
       visibility: Visibility that will be applied to the java runtime target
     """
 
-    # The repository name in Bzlmod will be "<module canonical name>.<module extension name>.local_jdk"
+    # The repository name in Bzlmod will be "@~<module canonical name>~<module extension name>~local_jdk"
     # instead of "local_jdk", therefore we cannot just use it as the config_setting value,
     # because it won't match the default value of --java_runtime_version (which is "local_jdk").
-    name = name.split(".")[-1]
+    name = name.split("~")[-1]
 
     if runtime_name == None:
         runtime_name = name
@@ -89,9 +89,9 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
     native.alias(
         name = name + "_settings_alias",
         actual = select({
-            name + "_name_setting": name + "_name_setting",
-            name + "_version_setting": name + "_version_setting",
-            "//conditions:default": name + "_name_version_setting",
+            ":" + name + "_name_setting": ":" + name + "_name_setting",
+            ":" + name + "_version_setting": ":" + name + "_version_setting",
+            "//conditions:default": ":" + name + "_name_version_setting",
         }),
         visibility = ["//visibility:private"],
     )


### PR DESCRIPTION

Changes make the CI pass again.

Some labels need to be prepended `:` in order to make `bzlmod` work again (see changes in `toolchains/local_java_repository.bzl`). This change to `bzlmod` could have wider consequences, because not all user prepend `:` when listing dependencies and it was not required until now.

Without upgrading JDKs the build fails with:
```
examples/hello_world/HelloWorld.java:16: error: [strict] Using type java.lang.String from an indirect dependency (TOOL_INFO: "/usr/local/google/home/ilist/.cache/bazel/_bazel_ilist/d6d4cb1dd98b785cc05b7860dd43f297/execroot/__main__/bazel-out/k8-fastbuild/bin/toolchains/platformclasspath.jar").
  public static void main (String[] args) {
```