### PR TITLE
Revert "Use `target_compatible_with` for Java runtimes"

### DIFF
--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -85,7 +85,7 @@ def remote_jdk8_repos(name = ""):
     maybe(
         remote_java_repository,
         name = "remote_jdk8_linux_aarch64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
         ],
@@ -100,7 +100,7 @@ def remote_jdk8_repos(name = ""):
     maybe(
         remote_java_repository,
         name = "remote_jdk8_linux",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
@@ -115,7 +115,7 @@ def remote_jdk8_repos(name = ""):
     maybe(
         remote_java_repository,
         name = "remote_jdk8_macos_aarch64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
@@ -129,7 +129,7 @@ def remote_jdk8_repos(name = ""):
     maybe(
         remote_java_repository,
         name = "remote_jdk8_macos",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
@@ -144,7 +144,7 @@ def remote_jdk8_repos(name = ""):
     maybe(
         remote_java_repository,
         name = "remote_jdk8_windows",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
@@ -171,7 +171,7 @@ def remote_jdk11_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk11_linux",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
@@ -187,7 +187,7 @@ def remote_jdk11_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk11_linux_aarch64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:aarch64",
         ],
@@ -203,7 +203,7 @@ def remote_jdk11_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk11_linux_ppc64le",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:ppc",
         ],
@@ -219,7 +219,7 @@ def remote_jdk11_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk11_linux_s390x",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:s390x",
         ],
@@ -235,7 +235,7 @@ def remote_jdk11_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk11_macos",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
@@ -251,7 +251,7 @@ def remote_jdk11_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk11_macos_aarch64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
@@ -267,7 +267,7 @@ def remote_jdk11_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk11_win",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
@@ -283,7 +283,7 @@ def remote_jdk11_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk11_win_arm64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:arm64",
         ],
@@ -300,7 +300,7 @@ def remote_jdk15_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk15_linux",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
@@ -316,7 +316,7 @@ def remote_jdk15_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk15_macos",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
@@ -332,7 +332,7 @@ def remote_jdk15_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk15_macos_aarch64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
@@ -348,7 +348,7 @@ def remote_jdk15_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk15_win",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
@@ -366,7 +366,7 @@ def remote_jdk16_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk16_linux",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
@@ -382,7 +382,7 @@ def remote_jdk16_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk16_macos",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
@@ -398,7 +398,7 @@ def remote_jdk16_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk16_macos_aarch64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
@@ -414,7 +414,7 @@ def remote_jdk16_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk16_win",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
@@ -432,7 +432,7 @@ def remote_jdk17_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk17_linux",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
         ],
@@ -448,7 +448,7 @@ def remote_jdk17_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk17_macos",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
         ],
@@ -464,7 +464,7 @@ def remote_jdk17_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk17_macos_aarch64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:aarch64",
         ],
@@ -479,7 +479,7 @@ def remote_jdk17_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk17_win",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",
         ],
@@ -494,7 +494,7 @@ def remote_jdk17_repos():
     maybe(
         remote_java_repository,
         name = "remotejdk17_win_arm64",
-        target_compatible_with = [
+        exec_compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:arm64",
         ],

--- a/toolchains/remote_java_repository.bzl
+++ b/toolchains/remote_java_repository.bzl
@@ -31,17 +31,17 @@ _toolchain_config = repository_rule(
     },
 )
 
-def remote_java_repository(name, version, target_compatible_with = None, prefix = "remotejdk", **kwargs):
+def remote_java_repository(name, version, exec_compatible_with, prefix = "remotejdk", **kwargs):
     """Imports and registers a JDK from a http archive.
 
-    Toolchain resolution is determined with target_compatible_with
+    Toolchain resolution is determined with exec_compatible_with
     parameter and constrained with --java_runtime_version flag either having value
     of "version" or "{prefix}_{version}" parameters.
 
     Args:
       name: A unique name for this rule.
       version: Version of the JDK imported.
-      target_compatible_with: Target platform constraints (CPU and OS) for this JDK.
+      exec_compatible_with: Platform constraints (CPU and OS) for this JDK.
       prefix: Optional alternative prefix for configuration flag value used to determine this JDK.
       **kwargs: Refer to http_archive documentation
     """
@@ -73,7 +73,7 @@ alias(
 )
 toolchain(
     name = "toolchain",
-    target_compatible_with = {target_compatible_with},
+    exec_compatible_with = {exec_compatible_with},
     target_settings = [":version_or_prefix_version_setting"],
     toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
     toolchain = "{toolchain}",
@@ -81,7 +81,7 @@ toolchain(
 """.format(
             prefix = prefix,
             version = version,
-            target_compatible_with = target_compatible_with,
+            exec_compatible_with = exec_compatible_with,
             toolchain = "@{repo}//:jdk".format(repo = name),
         ),
     )


### PR DESCRIPTION
This reverts commit 338c4184064f77d3d6ca8eae2bc5a605f8ea0da4.

This is probably not the right fix, but it fixes #64 for me.