### PR TITLE
refactor MODULE.bazel file

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_java",
     compatibility_level = 1,
-    version = "4.0.0",
+    version = "5.1.0",
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
@@ -25,6 +25,7 @@ use_repo(toolchains, "remote_java_tools_darwin")
 
 # Declare local jdk repo
 use_repo(toolchains, "local_jdk")
+
 register_toolchains("@local_jdk//:runtime_toolchain_definition")
 
 # Declare all remote jdk toolchain config repos
@@ -50,6 +51,7 @@ EXTRA_REMOTE_JDK11_REPOS = [
 ]
 
 REMOTE_JDK_REPOS = [("remotejdk" + version + "_" + platform) for version in JDK_VERSIONS for platform in PLATFORMS] + EXTRA_REMOTE_JDK11_REPOS
+
 [use_repo(
     toolchains,
     repo + "_toolchain_config_repo",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,33 @@
+module(
+    name = "rules_java",
+    compatibility_level = 1,
+    version = "4.0.0",
+)
+
+bazel_dep(name = "platforms", version = "0.0.4")
+bazel_dep(name = "rules_cc", version = "0.0.1")
+
+# rules_proto is required by @remote_java_tools, which is loaded via module extension.
+bazel_dep(name = "rules_proto", version = "4.0.0")
+
+register_toolchains("//toolchains:all")
+
+toolchains = use_extension("//java:extensions.bzl", "toolchains")
+
+# Declare remote java tools repos
+use_repo(toolchains, "remote_java_tools")
+
+use_repo(toolchains, "remote_java_tools_linux")
+
+use_repo(toolchains, "remote_java_tools_windows")
+
+use_repo(toolchains, "remote_java_tools_darwin")
+
+# Declare local jdk repo
+use_repo(toolchains, "local_jdk")
+register_toolchains("@local_jdk//:runtime_toolchain_definition")
+
+# Declare all remote jdk toolchain config repos
 JDK_VERSIONS = [
     "11",
     "15",
@@ -20,44 +50,12 @@ EXTRA_REMOTE_JDK11_REPOS = [
 ]
 
 REMOTE_JDK_REPOS = [("remotejdk" + version + "_" + platform) for version in JDK_VERSIONS for platform in PLATFORMS] + EXTRA_REMOTE_JDK11_REPOS
-
-REMOTE_JAVA_TOOLCHAINS = [("@" + name + "_toolchain_config_repo//:toolchain") for name in REMOTE_JDK_REPOS]
-
-module(
-    name = "rules_java",
-    compatibility_level = 1,
-    toolchains_to_register = [
-        "//toolchains:all",
-        "@local_jdk//:runtime_toolchain_definition",
-    ] + REMOTE_JAVA_TOOLCHAINS,
-    version = "4.0.0",
-)
-
-bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_cc", version = "0.0.1")
-
-# rules_proto is required by @remote_java_tools, which is loaded via module extension.
-bazel_dep(name = "rules_proto", version = "4.0.0")
-
-toolchains = use_extension("//java:extensions.bzl", "toolchains")
-
-# Declare remote java tools repos
-use_repo(toolchains, "remote_java_tools")
-
-use_repo(toolchains, "remote_java_tools_linux")
-
-use_repo(toolchains, "remote_java_tools_windows")
-
-use_repo(toolchains, "remote_java_tools_darwin")
-
-# Declare local jdk repo
-use_repo(toolchains, "local_jdk")
-
-# Declare all remote jdk toolchain config repos
 [use_repo(
     toolchains,
     repo + "_toolchain_config_repo",
 ) for repo in REMOTE_JDK_REPOS]
+
+[register_toolchains("@" + name + "_toolchain_config_repo//:toolchain") for name in REMOTE_JDK_REPOS]
 
 # Dev dependencies
 bazel_dep(name = "rules_pkg", dev_dependency = True, version = "0.5.1")


### PR DESCRIPTION
Use `register_toolchains(...)` instead of `module(..., toolchains_to_register = [...])`. The former allows us to put the `module` directive at the very top of the file, improving readability.