### PR TITLE
Include AUTHORS file in releases

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,6 +5,7 @@ exports_files(["LICENSE"])
 filegroup(
     name = "distribution",
     srcs = [
+        "AUTHORS",
         "BUILD",
         "LICENSE",
         "//java:srcs",


### PR DESCRIPTION
It is critical for downstream users to have documented copyright information in the software package that they download.