### PR TITLE
Fix problems with release and bump version to 5.3.3

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_java-{TAG}.tar.gz"
 }

--- a/BUILD
+++ b/BUILD
@@ -8,6 +8,7 @@ filegroup(
         "AUTHORS",
         "BUILD",
         "LICENSE",
+        "MODULE.bazel",
         "//java:srcs",
         "//toolchains:srcs",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_java",
     compatibility_level = 1,
-    version = "5.3.2",
+    version = "5.3.3",
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "5.3.2"
+version = "5.3.3"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:


### PR DESCRIPTION
Adding MODULE.bazel into the release archive, fixing url to point to actual release url.