### PR TITLE
Make list of codeowners shorter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,4 +14,4 @@
 # Component owners
 # ----------------
 
-* @lberki @comius @c-mita @oquenchil @cushon @katre @bazelbuild/java-team
+* @comius @bazelbuild/java-team


### PR DESCRIPTION
Having a long list, pings all the reviewers each time, creating noise.