### PR TITLE
Fix failures and bump version to 5.3.5

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,4 +5,4 @@ tasks:
     name: "Verify build targets"
     platform: ${{ platform }}
     build_targets:
-      - "@rules_java//..."
+      - "@rules_java//java/..."

--- a/BUILD
+++ b/BUILD
@@ -12,5 +12,5 @@ filegroup(
         "//java:srcs",
         "//toolchains:srcs",
     ],
-    visibility = ["@//distro:__pkg__"],
+    visibility = ["//distro:__pkg__"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,11 +1,11 @@
 module(
     name = "rules_java",
     compatibility_level = 1,
-    version = "5.3.4",
+    version = "5.3.5",
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_cc", version = "0.0.1")
+bazel_dep(name = "rules_cc", version = "0.0.2")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 
 # rules_proto is required by @remote_java_tools, which is loaded via module extension.

--- a/java/BUILD
+++ b/java/BUILD
@@ -6,8 +6,8 @@ licenses(["notice"])
 
 filegroup(
     name = "srcs",
-    srcs = glob(["**"]) + ["@//java/private:srcs"],
-    visibility = ["@//:__pkg__"],
+    srcs = glob(["**"]) + ["//java/private:srcs"],
+    visibility = ["//:__pkg__"],
 )
 
 bzl_library(

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "5.3.4"
+version = "5.3.5"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/private/BUILD
+++ b/java/private/BUILD
@@ -5,11 +5,11 @@ licenses(["notice"])
 bzl_library(
     name = "private",
     srcs = ["native.bzl"],
-    visibility = ["@//java:__pkg__"],
+    visibility = ["//java:__pkg__"],
 )
 
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["@//java:__pkg__"],
+    visibility = ["//java:__pkg__"],
 )

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -22,7 +22,7 @@ licenses(["notice"])
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
-    visibility = ["@//:__pkg__"],
+    visibility = ["//:__pkg__"],
 )
 
 # Used to distinguish toolchains used for Java development, ie the JavaToolchainProvider.

--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -177,6 +177,7 @@ def java_runtime_files(name, srcs):
     native.filegroup(
         name = name,
         srcs = srcs,
+        tags = ["manual"],
     )
     for src in srcs:
         native.genrule(
@@ -185,6 +186,7 @@ def java_runtime_files(name, srcs):
             toolchains = ["//toolchains:current_java_runtime"],
             cmd = "cp $(JAVABASE)/%s $@" % src,
             outs = [src],
+            tags = ["manual"],
         )
 
 def _bootclasspath_impl(ctx):


### PR DESCRIPTION
 - bumped rules_cc to 0.0.2, to be consistent with bazel_tools
 - removed all @// labels
 - tagged some targets in //toolchains/... as manual, so that `build //toolchains/... wouldn't break
 - build still breaks on some non-existent files in java_tools_prebuilt repository; those are never selected though
 - thus changed testing from @rules_java//... to @rules_java//java/...
 - bumped version to 5.3.5