### PR TITLE
Add default toolchains

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,5 +60,10 @@ REMOTE_JDK_REPOS = [("remotejdk" + version + "_" + platform) for version in JDK_
 
 [register_toolchains("@" + name + "_toolchain_config_repo//:toolchain") for name in REMOTE_JDK_REPOS]
 
+# Register defaults last
+DEFAULT_VERSION="11"
+DEFAULT_REMOTE_JDK_REPOS = [("remotejdk" + DEFAULT_VERSION + "_" + platform) for platform in PLATFORMS] + EXTRA_REMOTE_JDK11_REPOS
+[register_toolchains("@" + name + "_toolchain_config_repo//:toolchain_without_constraints") for name in DEFAULT_REMOTE_JDK_REPOS]
+
 # Dev dependencies
 bazel_dep(name = "rules_pkg", dev_dependency = True, version = "0.5.1")

--- a/toolchains/remote_java_repository.bzl
+++ b/toolchains/remote_java_repository.bzl
@@ -78,6 +78,13 @@ toolchain(
     toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
     toolchain = "{toolchain}",
 )
+toolchain(
+    name = "toolchain_without_constraints",
+    target_compatible_with = {target_compatible_with},
+    toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
+    toolchain = "{toolchain}",
+)
+
 """.format(
             prefix = prefix,
             version = version,


### PR DESCRIPTION
After removing the default value for `--java_language_version` and `--tool_java_language_version` in https://github.com/bazelbuild/bazel/commit/f23440b60337c9d74b9dfde1f7fd66e42181714f
the users would need to set the value to obtain a toolchain.

Adding a default toolchain last, will select it even when the flag is not set.

Addresses: https://github.com/bazelbuild/continuous-integration/issues/1518