### PR TITLE
Update remote jdks.

### DIFF
--- a/java/extensions.bzl
+++ b/java/extensions.bzl
@@ -13,14 +13,13 @@
 # limitations under the License.
 """Module extensions for rules_java."""
 
-load("//java:repositories.bzl", "java_tools_repos", "local_jdk_repo", "remote_jdk11_repos", "remote_jdk15_repos", "remote_jdk16_repos", "remote_jdk17_repos")
+load("//java:repositories.bzl", "java_tools_repos", "local_jdk_repo", "remote_jdk11_repos", "remote_jdk17_repos", "remote_jdk19_repos")
 
 def _toolchains_impl(_ctx):
     java_tools_repos()
     local_jdk_repo()
     remote_jdk11_repos()
-    remote_jdk15_repos()
-    remote_jdk16_repos()
     remote_jdk17_repos()
+    remote_jdk19_repos()
 
 toolchains = module_extension(implementation = _toolchains_impl)


### PR DESCRIPTION
Consistent with Bazel's policy of supporting JDK LTS releases and the latest non-LTS release, remove JDK 15+16 and add JDK 19.
