### PR TITLE
Updates to jdk versions to fix failing presubmits

### DIFF
--- a/java/extensions.bzl
+++ b/java/extensions.bzl
@@ -13,14 +13,13 @@
 # limitations under the License.
 """Module extensions for rules_java."""
 
-load("//java:repositories.bzl", "java_tools_repos", "local_jdk_repo", "remote_jdk11_repos", "remote_jdk15_repos", "remote_jdk16_repos", "remote_jdk17_repos")
+load("//java:repositories.bzl", "java_tools_repos", "local_jdk_repo", "remote_jdk11_repos", "remote_jdk17_repos", "remote_jdk19_repos")
 
 def _toolchains_impl(_ctx):
     java_tools_repos()
     local_jdk_repo()
     remote_jdk11_repos()
-    remote_jdk15_repos()
-    remote_jdk16_repos()
     remote_jdk17_repos()
+    remote_jdk19_repos()    
 
 toolchains = module_extension(implementation = _toolchains_impl)


### PR DESCRIPTION
Hi @comius while creating https://github.com/bazelbuild/rules_java/pull/89, we noticed that some presubmits are failing with this error
```
(15:54:16) ERROR: Traceback (most recent call last):
--
  | File "C:/b/bk-windows-p5rm/bazel/rules-java-java/java/extensions.bzl", line 16, column 94, in <toplevel>
  | load("//java:repositories.bzl", "java_tools_repos", "local_jdk_repo", "remote_jdk11_repos", "remote_jdk15_repos", "remote_jdk16_repos", "remote_jdk17_repos")
  | Error: file '//java:repositories.bzl' does not contain symbol 'remote_jdk15_repos' (did you mean 'remote_jdk11_repos'?)
  | (15:54:16) ERROR: Analysis of target '//examples/hello_world:hello_world' failed; build aborted: Error loading '//java:extensions.bzl' for module extensions, requested by <root>/MODULE.bazel:16:27: initialization of module 'java/extensions.bzl' failed: initialization of module 'java/extensions.bzl' failed
  | (15:54:16) INFO: Elapsed time: 2.284s
  | (15:54:16) INFO: 0 processes.
  | (15:54:16) ERROR: Build did NOT complete successfully
  | bazel build failed with exit code 1
  | 🚨 Error: The command exited with status 1
```

It looks like this commit changed some things (https://github.com/bazelbuild/rules_java/commit/a38710744f9f846f8a8f88e689303909323d8967)?. I attempted some changes to unblock us, but please let me know if this isn't right.