### PR TITLE
More updates to fix failing presubmits

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,9 +29,8 @@ register_toolchains("@local_jdk//:runtime_toolchain_definition")
 # Declare all remote jdk toolchain config repos
 JDK_VERSIONS = [
     "11",
-    "15",
-    "16",
     "17",
+    "19",
 ]
 
 PLATFORMS = [


### PR DESCRIPTION
Similar to https://github.com/bazelbuild/rules_java/pull/90, because of changes in https://github.com/bazelbuild/rules_java/commit/a38710744f9f846f8a8f88e689303909323d8967.

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/110264242/222862335-e020e367-ae6c-470d-a9f6-fb0abd78544c.png">

@comius 