### PR TITLE
Update java_tools to v12.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_java",
-    version = "6.0.0",
+    version = "5.5.0",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_java",
-    version = "5.4.1",
+    version = "6.0.0",
     compatibility_level = 1,
 )
 
@@ -19,7 +19,8 @@ toolchains = use_extension("//java:extensions.bzl", "toolchains")
 use_repo(toolchains, "remote_java_tools")
 use_repo(toolchains, "remote_java_tools_linux")
 use_repo(toolchains, "remote_java_tools_windows")
-use_repo(toolchains, "remote_java_tools_darwin")
+use_repo(toolchains, "remote_java_tools_darwin_x86_64")
+use_repo(toolchains, "remote_java_tools_darwin_arm64")
 
 # Declare local jdk repo
 use_repo(toolchains, "local_jdk")

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "6.0.0"
+version = "5.5.0"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "5.4.1"
+version = "6.0.0"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -52,6 +52,16 @@ def java_tools_repos():
 
     maybe(
         http_archive,
+        name = "remote_java_tools_darwin",
+        sha256 = "abc434be713ee9e1fd6525d7a7bd9d7cdff6e27ae3ca9d96420490e7ff6e28a3",
+        urls = [
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_x86_64-v12.0.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_x86_64-v12.0.zip",
+        ],
+    )
+
+    maybe(
+        http_archive,
         name = "remote_java_tools_darwin_x86_64",
         sha256 = "abc434be713ee9e1fd6525d7a7bd9d7cdff6e27ae3ca9d96420490e7ff6e28a3",
         urls = [

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -23,40 +23,50 @@ def java_tools_repos():
     maybe(
         http_archive,
         name = "remote_java_tools",
-        sha256 = "af20366f926b1dadf8c084a51936116ef2f0db90e73e94b406c4ad8180f0788d",
+        sha256 = "6efab6ca6e16e02c90e62bbd08ca65f61527984ab78564ea7ad7a2692b2ffdbb",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.12/java_tools-v11.12.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.12/java_tools-v11.12.zip",
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools-v12.0.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools-v12.0.zip",
         ],
     )
 
     maybe(
         http_archive,
         name = "remote_java_tools_linux",
-        sha256 = "37f79597f5b8c1501b9c66ded8ac68c61205ad39ef3ceda0e24fbd0afa3cd97f",
+        sha256 = "4b8366b780387fc5ce69527ed287f2b444ee429d3325305ad062c92ac43c7fb6",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.12/java_tools_linux-v11.12.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.12/java_tools_linux-v11.12.zip",
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_linux-v12.0.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_linux-v12.0.zip",
         ],
     )
 
     maybe(
         http_archive,
         name = "remote_java_tools_windows",
-        sha256 = "43432ce4814513d6497661b4fede691982b3bdef7a1907808b096291f56a8001",
+        sha256 = "7b938f0c67d9d390f10489b1b9a4dabb51e39ecc94532c3acdf8c4c16900457f",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.12/java_tools_windows-v11.12.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.12/java_tools_windows-v11.12.zip",
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_windows-v12.0.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_windows-v12.0.zip",
         ],
     )
 
     maybe(
         http_archive,
-        name = "remote_java_tools_darwin",
-        sha256 = "aed319892b638efabd08405b8f835770e13e2465d20459876c5f457f2b6426f3",
+        name = "remote_java_tools_darwin_x86_64",
+        sha256 = "abc434be713ee9e1fd6525d7a7bd9d7cdff6e27ae3ca9d96420490e7ff6e28a3",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v11.12/java_tools_darwin-v11.12.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v11.12/java_tools_darwin-v11.12.zip",
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_x86_64-v12.0.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_x86_64-v12.0.zip",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "remote_java_tools_darwin_arm64",
+        sha256 = "24a47a5557ee2ccdacd10a54fe4c15d627c6aeaf7596a5dccf2e11a866a5a32a",
+        urls = [
+                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_arm64-v12.0.zip",
+                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_arm64-v12.0.zip",
         ],
     )
 

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -25,8 +25,8 @@ def java_tools_repos():
         name = "remote_java_tools",
         sha256 = "6efab6ca6e16e02c90e62bbd08ca65f61527984ab78564ea7ad7a2692b2ffdbb",
         urls = [
-                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools-v12.0.zip",
-                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools-v12.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools-v12.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools-v12.0.zip",
         ],
     )
 
@@ -35,8 +35,8 @@ def java_tools_repos():
         name = "remote_java_tools_linux",
         sha256 = "4b8366b780387fc5ce69527ed287f2b444ee429d3325305ad062c92ac43c7fb6",
         urls = [
-                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_linux-v12.0.zip",
-                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_linux-v12.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_linux-v12.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_linux-v12.0.zip",
         ],
     )
 
@@ -45,8 +45,8 @@ def java_tools_repos():
         name = "remote_java_tools_windows",
         sha256 = "7b938f0c67d9d390f10489b1b9a4dabb51e39ecc94532c3acdf8c4c16900457f",
         urls = [
-                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_windows-v12.0.zip",
-                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_windows-v12.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_windows-v12.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_windows-v12.0.zip",
         ],
     )
 
@@ -55,8 +55,8 @@ def java_tools_repos():
         name = "remote_java_tools_darwin",
         sha256 = "abc434be713ee9e1fd6525d7a7bd9d7cdff6e27ae3ca9d96420490e7ff6e28a3",
         urls = [
-                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_x86_64-v12.0.zip",
-                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_x86_64-v12.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_x86_64-v12.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_x86_64-v12.0.zip",
         ],
     )
 
@@ -65,8 +65,8 @@ def java_tools_repos():
         name = "remote_java_tools_darwin_x86_64",
         sha256 = "abc434be713ee9e1fd6525d7a7bd9d7cdff6e27ae3ca9d96420490e7ff6e28a3",
         urls = [
-                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_x86_64-v12.0.zip",
-                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_x86_64-v12.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_x86_64-v12.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_x86_64-v12.0.zip",
         ],
     )
 
@@ -75,8 +75,8 @@ def java_tools_repos():
         name = "remote_java_tools_darwin_arm64",
         sha256 = "24a47a5557ee2ccdacd10a54fe4c15d627c6aeaf7596a5dccf2e11a866a5a32a",
         urls = [
-                "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_arm64-v12.0.zip",
-                "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_arm64-v12.0.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.0/java_tools_darwin_arm64-v12.0.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.0/java_tools_darwin_arm64-v12.0.zip",
         ],
     )
 

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -20,6 +20,7 @@ load("//toolchains:local_java_repository.bzl", "local_java_repository")
 load("//toolchains:remote_java_repository.bzl", "remote_java_repository")
 
 def java_tools_repos():
+    """ Declares the remote java_tools repositories """
     maybe(
         http_archive,
         name = "remote_java_tools",

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -126,7 +126,8 @@ cc_library(
     )
     for OS in [
         "linux",
-        "darwin",
+        "darwin_x86_64",
+        "darwin_arm64",
         "windows",
     ]
 ]
@@ -142,7 +143,8 @@ alias(
 alias(
     name = "ijar_prebuilt_binary_or_cc_binary",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": ":ijar_prebuilt_binary_darwin",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":ijar_prebuilt_binary_darwin_x86_64",
+        "@bazel_tools//src/conditions:darwin_arm64": ":ijar_prebuilt_binary_darwin_arm64",
         "@bazel_tools//src/conditions:linux_x86_64": ":ijar_prebuilt_binary_linux",
         "@bazel_tools//src/conditions:windows": ":ijar_prebuilt_binary_windows",
         "//conditions:default": "@remote_java_tools//:ijar_cc_binary",
@@ -152,7 +154,8 @@ alias(
 alias(
     name = "ijar_prebuilt_binary",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": ":ijar_prebuilt_binary_darwin",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":ijar_prebuilt_binary_darwin_x86_64",
+        "@bazel_tools//src/conditions:darwin_arm64": ":ijar_prebuilt_binary_darwin_arm64",
         "@bazel_tools//src/conditions:linux_x86_64": ":ijar_prebuilt_binary_linux",
         "@bazel_tools//src/conditions:windows": ":ijar_prebuilt_binary_windows",
     }),
@@ -172,7 +175,8 @@ alias(
 alias(
     name = "singlejar_prebuilt_or_cc_binary",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": ":prebuilt_singlejar_darwin",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":prebuilt_singlejar_darwin_x86_64",
+        "@bazel_tools//src/conditions:darwin_arm64": ":prebuilt_singlejar_darwin_arm64",
         "@bazel_tools//src/conditions:linux_x86_64": ":prebuilt_singlejar_linux",
         "@bazel_tools//src/conditions:windows": ":prebuilt_singlejar_windows",
         "//conditions:default": "@remote_java_tools//:singlejar_cc_bin",
@@ -182,7 +186,8 @@ alias(
 alias(
     name = "prebuilt_singlejar",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": ":prebuilt_singlejar_darwin",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":prebuilt_singlejar_darwin_x86_64",
+        "@bazel_tools//src/conditions:darwin_arm64": ":prebuilt_singlejar_darwin_arm64",
         "@bazel_tools//src/conditions:linux_x86_64": ":prebuilt_singlejar_linux",
         "@bazel_tools//src/conditions:windows": ":prebuilt_singlejar_windows",
     }),

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -143,8 +143,8 @@ alias(
 alias(
     name = "ijar_prebuilt_binary_or_cc_binary",
     actual = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": ":ijar_prebuilt_binary_darwin_x86_64",
         "@bazel_tools//src/conditions:darwin_arm64": ":ijar_prebuilt_binary_darwin_arm64",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":ijar_prebuilt_binary_darwin_x86_64",
         "@bazel_tools//src/conditions:linux_x86_64": ":ijar_prebuilt_binary_linux",
         "@bazel_tools//src/conditions:windows": ":ijar_prebuilt_binary_windows",
         "//conditions:default": "@remote_java_tools//:ijar_cc_binary",
@@ -154,8 +154,8 @@ alias(
 alias(
     name = "ijar_prebuilt_binary",
     actual = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": ":ijar_prebuilt_binary_darwin_x86_64",
         "@bazel_tools//src/conditions:darwin_arm64": ":ijar_prebuilt_binary_darwin_arm64",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":ijar_prebuilt_binary_darwin_x86_64",
         "@bazel_tools//src/conditions:linux_x86_64": ":ijar_prebuilt_binary_linux",
         "@bazel_tools//src/conditions:windows": ":ijar_prebuilt_binary_windows",
     }),
@@ -175,8 +175,8 @@ alias(
 alias(
     name = "singlejar_prebuilt_or_cc_binary",
     actual = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": ":prebuilt_singlejar_darwin_x86_64",
         "@bazel_tools//src/conditions:darwin_arm64": ":prebuilt_singlejar_darwin_arm64",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":prebuilt_singlejar_darwin_x86_64",
         "@bazel_tools//src/conditions:linux_x86_64": ":prebuilt_singlejar_linux",
         "@bazel_tools//src/conditions:windows": ":prebuilt_singlejar_windows",
         "//conditions:default": "@remote_java_tools//:singlejar_cc_bin",
@@ -186,8 +186,8 @@ alias(
 alias(
     name = "prebuilt_singlejar",
     actual = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": ":prebuilt_singlejar_darwin_x86_64",
         "@bazel_tools//src/conditions:darwin_arm64": ":prebuilt_singlejar_darwin_arm64",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":prebuilt_singlejar_darwin_x86_64",
         "@bazel_tools//src/conditions:linux_x86_64": ":prebuilt_singlejar_linux",
         "@bazel_tools//src/conditions:windows": ":prebuilt_singlejar_windows",
     }),


### PR DESCRIPTION
Also splits the darwin prebuilts into x86_64 and arm64

Work towards https://github.com/bazelbuild/bazel/issues/17780