### PR TITLE
Add mirror url for `remote_jdk8_macos_aarch64` repository 

### DIFF
--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -139,6 +139,7 @@ def remote_jdk8_repos(name = ""):
         sha256 = "e5c84a46bbd985c3a53358db9c97a6fd4930f92b833c3163a0d1e47dab59768c",
         strip_prefix = "zulu8.62.0.19-ca-jdk8.0.332-macosx_aarch64",
         urls = [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-macosx_aarch64.tar.gz",
             "https://cdn.azul.com/zulu/bin/zulu8.62.0.19-ca-jdk8.0.332-macosx_aarch64.tar.gz",
         ],
         version = "8",


### PR DESCRIPTION
Mirror added in https://github.com/bazelbuild/bazel/issues/17870

_relates_ to https://github.com/bazelbuild/rules_java/pull/56#issuecomment-1130402379