### PR TITLE
Fix --incompatible_disallow_empty_glob

### DIFF
--- a/toolchains/jdk.BUILD
+++ b/toolchains/jdk.BUILD
@@ -173,7 +173,10 @@ filegroup(
 
 filegroup(
     name = "jdk-include",
-    srcs = glob(["include/**"]),
+    srcs = glob(
+        ["include/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(


### PR DESCRIPTION
This is the same as https://github.com/bazelbuild/bazel/commit/c2ddbd1954af5baab63b93f2b055a410a27832c8