### PR TITLE
Add remote_jdk19_repos to rules_java_dependencies

### DIFF
--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -451,6 +451,7 @@ def rules_java_dependencies():
     local_jdk_repo()
     remote_jdk11_repos()
     remote_jdk17_repos()
+    remote_jdk19_repos()
     java_tools_repos()
 
 def rules_java_toolchains(name = "toolchains"):


### PR DESCRIPTION
# Problem

rules_java_toolchains will register a toolchain for each element in the cross product of `JDK_VERSIONS` and `PLATFORMS`. Notably, it will register toolchains for jdk version 19, which causes an issue because `remote_jdk19_repos` is not invoked in `rules_java_dependencies`.

# Solution

Simply add `remote_jdk19_repos` to `rules_java_dependencies`.