### PR TITLE
Fix remotejdk_11 toolchain registration

### DIFF
--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -211,7 +211,7 @@ alias(
     actual = ":toolchain",
 )
 
-RELEASES = (8, 9, 10, 11)
+RELEASES = (8, 9, 10)
 
 [
     default_java_toolchain(
@@ -222,6 +222,15 @@ RELEASES = (8, 9, 10, 11)
     )
     for release in RELEASES
 ]
+
+# A toolchain that targets java 11.
+default_java_toolchain(
+    name = "toolchain_jdk_11",
+    configuration = dict(),
+    java_runtime = "//toolchains:remote_jdk11",
+    source_version = "11",
+    target_version = "11",
+)
 
 # A toolchain that targets java 15.
 default_java_toolchain(


### PR DESCRIPTION
The registration for JDK11 was defaulting to java_runtime of JDK17, causing issues. Instead, register the remotejdk_11 toolchain explicitly using the proper `java_runtime` value of JDK11. Oddly, the naming is inconsistent in this file, `remote_jdk11` and `remotejdk_11`. It appears to be inadvertent 🤷 