### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_java",
-    version = "5.5.0",
+    version = "6.0.0",
     compatibility_level = 1,
 )
 

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "5.5.0"
+version = "6.0.0"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:


### PR DESCRIPTION
Changing major version because the `remote_java_tools_darwin` repo is now removed