### PR TITLE
Fix docs after split from bazel_tools

### DIFF
--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -261,7 +261,10 @@ _local_java_repository_rule = repository_rule(
 )
 
 def local_java_repository(name, java_home = "", version = "", build_file = None, build_file_content = None, **kwargs):
-    """Registers a runtime toolchain for local JDK and creates an unregistered compile toolchain.
+    """Defines runtime and compile toolchains for a local JDK.
+
+    Register the toolchains defined by this macro via `register_toolchains("@<name>//:all")`, where
+    `<name>` is the value of the `name` parameter.
 
     Toolchain resolution is constrained with --java_runtime_version flag
     having value of the "name" or "version" parameter.

--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Rules for importing and registering a local JDK."""
+"""Rules for importing a local JDK."""
 
 load("//java:defs.bzl", "java_runtime")
 load(":default_java_toolchain.bzl", "default_java_toolchain")

--- a/toolchains/remote_java_repository.bzl
+++ b/toolchains/remote_java_repository.bzl
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Rules for importing and registering JDKs from http archive.
+"""Rules for importing JDKs from http archive.
 
-Rule remote_java_repository imports and registers JDK with the toolchain resolution.
+Rule remote_java_repository imports a JDK and creates toolchain definitions for it.
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/toolchains/remote_java_repository.bzl
+++ b/toolchains/remote_java_repository.bzl
@@ -33,7 +33,10 @@ _toolchain_config = repository_rule(
 )
 
 def remote_java_repository(name, version, target_compatible_with = None, prefix = "remotejdk", **kwargs):
-    """Imports and registers a JDK from a http archive.
+    """Imports a JDK from a http archive and creates runtime toolchain definitions for it.
+
+    Register the toolchains defined by this macro via `register_toolchains("@<name>//:all")`, where
+    `<name>` is the value of the `name` parameter.
 
     Toolchain resolution is determined with target_compatible_with
     parameter and constrained with --java_runtime_version flag either having value


### PR DESCRIPTION
The `*_java_repository` macros no longer register toolchains.