### PR TITLE
Update java_tools v12.5 and rules_java 6.2.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_java",
-    version = "6.2.1",
+    version = "6.2.2",
     compatibility_level = 1,
 )
 

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "6.2.1"
+version = "6.2.2"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -25,50 +25,45 @@ def java_tools_repos():
     maybe(
         http_archive,
         name = "remote_java_tools",
-        sha256 = "e91fbced948cdafce21c29c9ce006de19a2e7fc40706aac6197096d0847ae93d",
+        sha256 = "942b3d88ebd785a5face38049077a1f8dab5a3500f5ebd0c0df090244acc4e16",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.4/java_tools-v12.4.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.4/java_tools-v12.4.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools-v12.5-rc1.zip",
         ],
     )
 
     maybe(
         http_archive,
         name = "remote_java_tools_linux",
-        sha256 = "ed1438453d5142c0cf022a43a21255d4a764f9f221cce08c17a2285d04479a06",
+        sha256 = "45dda5441b46385e8ec95d3bc4a04b9337a6ff837bb41bdaa6247d8d36edceae",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.4/java_tools_linux-v12.4.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.4/java_tools_linux-v12.4.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools_linux-v12.5-rc1.zip",
         ],
     )
 
     maybe(
         http_archive,
         name = "remote_java_tools_windows",
-        sha256 = "11b61fa63da07380dec212448a0e44b66f3d1ee5469f1c8a2845ca8a4431d851",
+        sha256 = "0b319cf762e256133f8d0f5f99fd7d35ca4cf00f35e7c0e8aea1b9fcd9cf4fb0",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.4/java_tools_windows-v12.4.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.4/java_tools_windows-v12.4.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools_windows-v12.5-rc1.zip",
         ],
     )
 
     maybe(
         http_archive,
         name = "remote_java_tools_darwin_x86_64",
-        sha256 = "564ed4f744ed947f27641ac1dc256ef294f38a7b0955b70f4c9407173a838a86",
+        sha256 = "7e96d0310222e9c27e4c87987978c0c59a0acb97cebdbd838ff652a13abbed77",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.4/java_tools_darwin_x86_64-v12.4.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.4/java_tools_darwin_x86_64-v12.4.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools_darwin_x86_64-v12.5-rc1.zip",
         ],
     )
 
     maybe(
         http_archive,
         name = "remote_java_tools_darwin_arm64",
-        sha256 = "7c0f2b7295b1738e7192731124730bfd9a9b2034895fa99a98dd5b8fb4a96c1b",
+        sha256 = "5fb927b24043dd79010b54be31ec5f18b38ee9dbd9fd03d8353232431a7e2392",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.4/java_tools_darwin_arm64-v12.4.zip",
-            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.4/java_tools_darwin_arm64-v12.4.zip",
+            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools_darwin_arm64-v12.5-rc1.zip",
         ],
     )
 

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -27,7 +27,8 @@ def java_tools_repos():
         name = "remote_java_tools",
         sha256 = "942b3d88ebd785a5face38049077a1f8dab5a3500f5ebd0c0df090244acc4e16",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools-v12.5-rc1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.5/java_tools-v12.5.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.5/java_tools-v12.5.zip",
         ],
     )
 
@@ -36,7 +37,8 @@ def java_tools_repos():
         name = "remote_java_tools_linux",
         sha256 = "45dda5441b46385e8ec95d3bc4a04b9337a6ff837bb41bdaa6247d8d36edceae",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools_linux-v12.5-rc1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.5/java_tools_linux-v12.5.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.5/java_tools_linux-v12.5.zip",
         ],
     )
 
@@ -45,7 +47,8 @@ def java_tools_repos():
         name = "remote_java_tools_windows",
         sha256 = "0b319cf762e256133f8d0f5f99fd7d35ca4cf00f35e7c0e8aea1b9fcd9cf4fb0",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools_windows-v12.5-rc1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.5/java_tools_windows-v12.5.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.5/java_tools_windows-v12.5.zip",
         ],
     )
 
@@ -54,7 +57,8 @@ def java_tools_repos():
         name = "remote_java_tools_darwin_x86_64",
         sha256 = "7e96d0310222e9c27e4c87987978c0c59a0acb97cebdbd838ff652a13abbed77",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools_darwin_x86_64-v12.5-rc1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.5/java_tools_darwin_x86_64-v12.5.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.5/java_tools_darwin_x86_64-v12.5.zip",
         ],
     )
 
@@ -63,7 +67,8 @@ def java_tools_repos():
         name = "remote_java_tools_darwin_arm64",
         sha256 = "5fb927b24043dd79010b54be31ec5f18b38ee9dbd9fd03d8353232431a7e2392",
         urls = [
-            "https://mirror.bazel.build/bazel_java_tools/release_candidates/java/v12.5/java_tools_darwin_arm64-v12.5-rc1.zip",
+            "https://mirror.bazel.build/bazel_java_tools/releases/java/v12.5/java_tools_darwin_arm64-v12.5.zip",
+            "https://github.com/bazelbuild/java_tools/releases/download/java_v12.5/java_tools_darwin_arm64-v12.5.zip",
         ],
     )
 


### PR DESCRIPTION
- https://github.com/bazelbuild/java_tools/issues/75
- Update rules_java version to 6.2.2 before creating the new release