### PR TITLE
Mark rules_java as compatible with Bazel >= 7.0.0-pre.20230710.5

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,6 +2,7 @@ module(
     name = "rules_java",
     version = "6.4.0",
     compatibility_level = 1,
+    bazel_compatibility = [">=7.0.0-pre.20230710.5"],
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")


### PR DESCRIPTION
Since #114, rules_java requires a version of Bazel that contains https://github.com/bazelbuild/bazel/commit/8715e9ae6f5c2fd42607018b3adaad14bf601a1c