### PR TITLE
Reference `platformclasspath` in `@bazel_tools`

### DIFF
--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -86,7 +86,7 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     singlejar = [Label("//toolchains:singlejar")],
     # Code to enumerate target JVM boot classpath uses host JVM. Because
     # java_runtime-s are involved, its implementation is in @bazel_tools.
-    bootclasspath = [Label("//toolchains:platformclasspath")],
+    bootclasspath = [Label("@bazel_tools//tools/jdk:platformclasspath")],
     source_version = "8",
     target_version = "8",
     reduced_classpath_incompatible_processors = [


### PR DESCRIPTION
The `platformclasspath` rule in `@rules_java` always requires a bootstrap Java runtime toolchain to be registered, but whether the commonly used toolchain macros in `@bazel_tools` register this toolchain depends on the version of Bazel that is running the build and the version of `rules_java` it bundles as `@rules_java_builtin`.

In order to support all Bazel versions, reference the `platformclasspath` in `@bazel_tools`, which in turn references the corresponding target in `@rules_java_builtin`, which may or may not be the current version of this code.