### PR TITLE
Fix docs on `local_java_repository`

### DIFF
--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -283,8 +283,17 @@ _local_java_repository_rule = repository_rule(
 def local_java_repository(name, java_home = "", version = "", build_file = None, build_file_content = None, **kwargs):
     """Defines runtime and compile toolchains for a local JDK.
 
-    Register the toolchains defined by this macro via `register_toolchains("@<name>//:all")`, where
-    `<name>` is the value of the `name` parameter.
+    Register the toolchains defined by this macro as follows (where `<name>` is the value of the
+    `name` parameter):
+    * Runtime toolchains only (recommended)
+      ```
+      register_toolchains("@<name>//:runtime_toolchain_definition")
+      register_toolchains("@<name>//:bootstrap_runtime_toolchain_definition")
+      ```
+    * Runtime and compilation toolchains:
+      ```
+      register_toolchains("@<name>//:all")
+      ```
 
     Toolchain resolution is constrained with --java_runtime_version flag
     having value of the "name" or "version" parameter.


### PR DESCRIPTION
The previously added recommendation to register the `:all` pseudo-target altered the previous behavior of the macro by also registering the compilation toolchain.