### PR TITLE
Set `java` on remote JDKs

### DIFF
--- a/toolchains/jdk_build_file.bzl
+++ b/toolchains/jdk_build_file.bzl
@@ -83,6 +83,13 @@ java_runtime(
         ":jdk-lib",
         ":jre",
     ],
+    # Provide the 'java` binary explicitly so that the correct path is used by
+    # Bazel even when the host platform differs from the execution platform.
+    # Exactly one of the two globs will be empty depending on the host platform.
+    # When --incompatible_disallow_empty_glob is enabled, each individual empty
+    # glob will fail without allow_empty = True, even if the overall result is
+    # non-empty.
+    java = glob(["bin/java.exe", "bin/java"], allow_empty = True)[0],
     version = {RUNTIME_VERSION},
 )
 """


### PR DESCRIPTION
If the `java` attribute on `java_runtime` isn't set, Bazel guesses it based on the host platform, which can be different from the execution platform.

https://github.com/bazelbuild/bazel/blob/04a05677e4714434ec196c45a4ccbd8e0ef2f0ff/src/main/java/com/google/devtools/build/lib/rules/java/JavaRuntime.java#L46

Work towards https://github.com/bazelbuild/bazel/issues/19587