### PR TITLE
Add jmods

### DIFF
--- a/toolchains/jdk_build_file.bzl
+++ b/toolchains/jdk_build_file.bzl
@@ -63,6 +63,14 @@ filegroup(
 )
 
 filegroup(
+    name = "jdk-jmods",
+    srcs = glob(
+        ["jmods/**"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
     name = "jdk-lib",
     srcs = glob(
         ["lib/**", "release"],
@@ -79,6 +87,7 @@ java_runtime(
     srcs = [
         ":jdk-bin",
         ":jdk-conf",
+        ":jdk-jmods",
         ":jdk-include",
         ":jdk-lib",
         ":jre",


### PR DESCRIPTION
The jmods is important for anybody attempting to use the `jlink` command with a custom `--add-modules` flag.