### PR TITLE
Revert "Reference `platformclasspath` in `@bazel_tools`"

### DIFF
--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -86,7 +86,7 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     singlejar = [Label("//toolchains:singlejar")],
     # Code to enumerate target JVM boot classpath uses host JVM. Because
     # java_runtime-s are involved, its implementation is in @bazel_tools.
-    bootclasspath = [Label("@bazel_tools//tools/jdk:platformclasspath")],
+    bootclasspath = [Label("//toolchains:platformclasspath")],
     source_version = "8",
     target_version = "8",
     reduced_classpath_incompatible_processors = [


### PR DESCRIPTION
This reverts commit 54e89daeacd9728f45b4c16b3834e16d5f40e11c.

Going through `@bazel_tools` to reference the bootstrap classpath is no longer needed with Bazel 7, which always uses toolchain macros that define the required bootstrap runtime toolchains.

Since the original problem didn't arise with Bzlmod, where the Java toolchains have always come from rules_java rather than bazel_tools, this fixes https://github.com/bazelbuild/bazel/issues/19837 for Bazel itself by allowing it to use the new bootstrap classpath rule while still being built with Bazel 6.4.0.