### PR TITLE
Merge rules_java 7.0.x release branch

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,6 +4,6 @@ tasks:
   verify_build_targets:
     name: "Verify build targets"
     platform: ${{ platform }}
-    bazel_version: 6.4.0rc5
+    bazel: 6.4.0rc5
     build_targets:
       - "@rules_java//java/..."

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,5 +4,6 @@ tasks:
   verify_build_targets:
     name: "Verify build targets"
     platform: ${{ platform }}
+    bazel_version: 6.4.0rc5
     build_targets:
       - "@rules_java//java/..."

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_java",
-    version = "7.0.4",
+    version = "7.0.5",
     compatibility_level = 1,
     bazel_compatibility = [">=6.4.0"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_java",
-    version = "7.0.0",
+    version = "7.0.1",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 module(
     name = "rules_java",
-    version = "7.0.2",
+    version = "7.0.3",
+    compatibility_level = 1,
     bazel_compatibility = [">=6.4.0"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_java",
-    version = "7.0.1",
-    compatibility_level = 1,
+    version = "7.0.2",
+    bazel_compatibility = [">=6.4.0"],
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,8 +2,8 @@ module(
     name = "rules_java",
     version = "7.0.6",
     # Requires @bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type.
-    compatibility_level = 1,
     bazel_compatibility = [">=6.4.0"],
+    compatibility_level = 1,
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_java",
-    version = "7.0.5",
+    version = "7.0.6",
     compatibility_level = 1,
     bazel_compatibility = [">=6.4.0"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_java",
-    version = "7.0.3",
+    version = "7.0.4",
     compatibility_level = 1,
     bazel_compatibility = [">=6.4.0"],
 )

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "7.0.0"
+version = "7.0.1"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "7.0.5"
+version = "7.0.6"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "7.0.2"
+version = "7.0.3"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "7.0.1"
+version = "7.0.2"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "7.0.4"
+version = "7.0.5"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -18,7 +18,7 @@ load("//java/private:native.bzl", "NativeJavaInfo", "NativeJavaPluginInfo", "nat
 # Do not touch: This line marks the end of loads; needed for PR importing.
 
 _MIGRATION_TAG = "__JAVA_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
-version = "7.0.3"
+version = "7.0.4"
 
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -257,62 +257,17 @@ alias(
     actual = ":toolchain",
 )
 
-RELEASES = (8, 9, 10, 11)
+RELEASES = (8, 9, 10, 11, 17, 21)
 
 [
     default_java_toolchain(
-        name = "toolchain_java%d" % release,
+        name = ("toolchain_java%d" if release <= 11 else "toolchain_jdk_%d") % release,
         configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
         source_version = "%s" % release,
         target_version = "%s" % release,
     )
     for release in RELEASES
 ]
-
-# A toolchain that targets java 14.
-default_java_toolchain(
-    name = "toolchain_jdk_14",
-    configuration = dict(),
-    java_runtime = "//toolchains:remotejdk_14",
-    source_version = "14",
-    target_version = "14",
-)
-
-# A toolchain that targets java 15.
-default_java_toolchain(
-    name = "toolchain_jdk_15",
-    configuration = dict(),
-    java_runtime = "//toolchains:remotejdk_15",
-    source_version = "15",
-    target_version = "15",
-)
-
-# A toolchain that targets java 16.
-default_java_toolchain(
-    name = "toolchain_jdk_16",
-    configuration = dict(),
-    java_runtime = "//toolchains:remotejdk_16",
-    source_version = "16",
-    target_version = "16",
-)
-
-# A toolchain that targets java 17.
-default_java_toolchain(
-    name = "toolchain_jdk_17",
-    configuration = dict(),
-    java_runtime = "//toolchains:remotejdk_17",
-    source_version = "17",
-    target_version = "17",
-)
-
-# A toolchain that targets java 21.
-default_java_toolchain(
-    name = "toolchain_jdk_21",
-    configuration = dict(),
-    java_runtime = "//toolchains:remotejdk_21",
-    source_version = "21",
-    target_version = "21",
-)
 
 default_java_toolchain(
     name = "prebuilt_toolchain",


### PR DESCRIPTION
We needed to release `rules_java` from this branch since head was incompatible with Bazel CI. 