### PR TITLE
Disable perfdata when running JavaToolchainCompileClasses or JavaToolchainCompileBootClasspath

### DIFF
--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -221,6 +221,7 @@ def _bootclasspath_impl(ctx):
     args.add("-target")
     args.add("8")
     args.add("-Xlint:-options")
+    args.add("-J-XX:-UsePerfData")
     args.add("-d")
     args.add_all([class_dir], expand_directories = False)
     args.add(ctx.file.src)
@@ -238,6 +239,7 @@ def _bootclasspath_impl(ctx):
 
     args = ctx.actions.args()
     args.add("-XX:+IgnoreUnrecognizedVMOptions")
+    args.add("-XX:-UsePerfData")
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED")
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED")
     args.add("--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED")


### PR DESCRIPTION
A [recent JDK update](https://github.com/openjdk/jdk/commit/84f23149e22561173feb0e34bca31a7345b43c89#diff-7313eb3d328797a7720fa1b2b73cd159934506593443e45534baad80cb1382b7R924-R927) started printing the following warning message from the JVM
```
[warning][perf,memops] Cannot use file /tmp/hsperfdata_username/2 because it is locked by another process (errno = 11)
``` 
on linux hosts.  Also referenced from https://github.com/bazelbuild/bazel/issues/3236

This PR disables the perfdata generation when running JavaToolchainCompileClasses or JavaToolchainCompileBootClasspath so this warning message won't be printed.