### PR TITLE
fix: add proto directory to dist

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -6,7 +6,10 @@ licenses(["notice"])
 
 filegroup(
     name = "srcs",
-    srcs = glob(["**"]) + ["//java/private:srcs"],
+    srcs = glob(["**"]) + [
+        "//java/private:srcs",
+        "//java/proto:srcs"
+    ],
     visibility = ["//:__pkg__"],
 )
 

--- a/java/proto/BUILD
+++ b/java/proto/BUILD
@@ -5,3 +5,9 @@ toolchain_type(name = "toolchain_type")
 
 # Toolchain type provided by proto_lang_toolchain rule and used by java_lite_proto_library
 toolchain_type(name = "lite_toolchain_type")
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//java:__pkg__"],
+)


### PR DESCRIPTION
the output from distribution artficat; 

```
$ tar -tf bazel-bin/distro/rules_java-7.3.0.tar.gz
./AUTHORS
./BUILD
./LICENSE
./MODULE.bazel
./WORKSPACE
./java/
./java/BUILD
./java/defs.bzl
./java/extensions.bzl
./java/java_single_jar.bzl
./java/java_utils.bzl
./java/private/
./java/private/BUILD
./java/private/native.bzl
./java/proto/
./java/proto/BUILD
./java/repositories.bzl
./toolchains/
./toolchains/BUILD
./toolchains/DumpPlatformClassPath.java
./toolchains/default_java_toolchain.bzl
./toolchains/fail_rule.bzl
./toolchains/java_toolchain_alias.bzl
./toolchains/jdk_build_file.bzl
./toolchains/local_java_repository.bzl
./toolchains/remote_java_repository.bzl
./toolchains/toolchain_utils.bzl
```