### PR TITLE
Remove explicit Bazel version from `presubmit.yml`

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,6 +4,5 @@ tasks:
   verify_build_targets:
     name: "Verify build targets"
     platform: ${{ platform }}
-    bazel: 7.0.0
     build_targets:
       - "@rules_java//java/..."


### PR DESCRIPTION
The BCR should be free to set this version and now uses 7.0.0 by default, which matches the compatibility of this ruleset.