### PR TITLE
Register Java 8 runtimes with Bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,15 @@ register_toolchains(
 
 # Declare all remote jdk toolchain config repos
 JDKS = {
+    # Must match JDK repos defined in remote_jdk8_repos()
+    "8": [
+        "linux",
+        "linux_aarch64",
+        "linux_s390x",
+        "macos",
+        "macos_aarch64",
+        "windows",
+    ],
     # Must match JDK repos defined in remote_jdk11_repos()
     "11": [
         "linux",
@@ -70,7 +79,7 @@ JDKS = {
     ],
 }
 
-REMOTE_JDK_REPOS = [("remotejdk" + version + "_" + platform) for version in JDKS for platform in JDKS[version]]
+REMOTE_JDK_REPOS = [(("remote_jdk" if version == "8" else "remotejdk") + version + "_" + platform) for version in JDKS for platform in JDKS[version]]
 
 [use_repo(
     toolchains,

--- a/java/extensions.bzl
+++ b/java/extensions.bzl
@@ -13,11 +13,20 @@
 # limitations under the License.
 """Module extensions for rules_java."""
 
-load("//java:repositories.bzl", "java_tools_repos", "local_jdk_repo", "remote_jdk11_repos", "remote_jdk17_repos", "remote_jdk21_repos")
+load(
+    "//java:repositories.bzl",
+    "java_tools_repos",
+    "local_jdk_repo",
+    "remote_jdk11_repos",
+    "remote_jdk17_repos",
+    "remote_jdk21_repos",
+    "remote_jdk8_repos",
+)
 
 def _toolchains_impl(_ctx):
     java_tools_repos()
     local_jdk_repo()
+    remote_jdk8_repos()
     remote_jdk11_repos()
     remote_jdk17_repos()
     remote_jdk21_repos()

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -167,19 +167,6 @@ def remote_jdk8_repos(name = ""):
         ],
         version = "8",
     )
-    REMOTE_JDK8_REPOS = [
-        "remote_jdk8_linux_aarch64",
-        "remote_jdk8_linux_s390x",
-        "remote_jdk8_linux",
-        "remote_jdk8_macos_aarch64",
-        "remote_jdk8_macos",
-        "remote_jdk8_windows",
-    ]
-    for name in REMOTE_JDK8_REPOS:
-        native.register_toolchains(
-            "@" + name + "_toolchain_config_repo//:toolchain",
-            "@" + name + "_toolchain_config_repo//:bootstrap_runtime_toolchain",
-        )
 
 def remote_jdk11_repos():
     """Imports OpenJDK 11 repositories."""
@@ -581,6 +568,8 @@ def rules_java_toolchains(name = "toolchains"):
         name: The name of this macro (not used)
     """
     JDKS = {
+        # Must match JDK repos defined in remote_jdk8_repos()
+        "8": ["linux", "linux_aarch64", "linux_s390x", "macos", "macos_aarch64", "windows"],
         # Must match JDK repos defined in remote_jdk11_repos()
         "11": ["linux", "linux_aarch64", "linux_ppc64le", "linux_s390x", "macos", "macos_aarch64", "win", "win_arm64"],
         # Must match JDK repos defined in remote_jdk17_repos()
@@ -589,7 +578,7 @@ def rules_java_toolchains(name = "toolchains"):
         "21": ["linux", "linux_aarch64", "macos", "macos_aarch64", "win"],
     }
 
-    REMOTE_JDK_REPOS = [("remotejdk" + version + "_" + platform) for version in JDKS for platform in JDKS[version]]
+    REMOTE_JDK_REPOS = [(("remote_jdk" if version == "8" else "remotejdk") + version + "_" + platform) for version in JDKS for platform in JDKS[version]]
 
     native.register_toolchains(
         "//toolchains:all",


### PR DESCRIPTION
These runtimes were only registered when using WORKSPACE.

Work towards bazelbuild/bazel#21769