### PR TITLE
Add JDK 8 `tools.jar` contents to bootclasspath

### DIFF
--- a/toolchains/DumpPlatformClassPath.java
+++ b/toolchains/DumpPlatformClassPath.java
@@ -187,6 +187,10 @@ public class DumpPlatformClassPath {
         jars.add(path);
       }
     }
+    Path toolsJar = javaHome.resolve("lib/tools.jar");
+    if (Files.exists(toolsJar)) {
+      jars.add(toolsJar);
+    }
     return jars;
   }
 


### PR DESCRIPTION
Work towards https://github.com/bazelbuild/bazel/issues/21771