### PR TITLE
Make jmods available from the jdk BUILD file

### DIFF
--- a/toolchains/jdk_build_file.bzl
+++ b/toolchains/jdk_build_file.bzl
@@ -92,4 +92,26 @@ java_runtime(
     java = glob(["bin/java.exe", "bin/java"], allow_empty = True)[0],
     version = {RUNTIME_VERSION},
 )
+
+filegroup(
+    name = "jdk-jmods",
+    srcs = glob(
+        ["jmods/**"],
+        allow_empty = True,
+    ),
+)
+
+java_runtime(
+    name = "jdk-with-jmods",
+    srcs = [
+        ":jdk-bin",
+        ":jdk-conf",
+        ":jdk-include",
+        ":jdk-lib",
+        ":jdk-jmods",
+        ":jre",
+    ],
+    java = glob(["bin/java.exe", "bin/java"], allow_empty = True)[0],
+    version = {RUNTIME_VERSION},
+)
 """


### PR DESCRIPTION
The PR at https://github.com/bazelbuild/rules_java/pull/135 looks dormant, this makes the change requested at https://github.com/bazelbuild/rules_java/pull/135#issuecomment-1797985514

I don't need the entire change here, having the jmods as a filegroup is sufficient for using jlink, but @cushon suggested adding the files as sources to the java_runtime as well, if I understood him correctly, so I did that too. If that's not necessary, let me know and I'll remove that part.