### PR TITLE
Mark `toolchains` extension as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_cc", version = "0.0.2")
-bazel_dep(name = "bazel_skylib", version = "1.2.0")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
 # Required by @remote_java_tools, which is loaded via module extension.
 bazel_dep(name = "rules_proto", version = "4.0.0")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,10 +4,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
+    sha256 = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
     ],
 )
 

--- a/java/extensions.bzl
+++ b/java/extensions.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Module extensions for rules_java."""
 
+load("@bazel_skylib//lib:modules.bzl", "modules")
 load(
     "//java:repositories.bzl",
     "java_tools_repos",
@@ -23,7 +24,7 @@ load(
     "remote_jdk8_repos",
 )
 
-def _toolchains_impl(_ctx):
+def _toolchains_impl():
     java_tools_repos()
     local_jdk_repo()
     remote_jdk8_repos()
@@ -31,4 +32,4 @@ def _toolchains_impl(_ctx):
     remote_jdk17_repos()
     remote_jdk21_repos()
 
-toolchains = module_extension(implementation = _toolchains_impl)
+toolchains = modules.as_extension(_toolchains_impl)


### PR DESCRIPTION
This avoids an unnecessary and verbose lockfile entry for rules_java users. Uses `bazel_skylib`'s `modules.as_extension` to automatically detect the availability of the `reproducible` feature.