### PR TITLE
Do not enable `use_all_repos` for toolchains extension

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "rules_cc", version = "0.0.2")
+bazel_dep(name = "bazel_features", version = "1.11.0")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 
 # Required by @remote_java_tools, which is loaded via module extension.

--- a/java/extensions.bzl
+++ b/java/extensions.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Module extensions for rules_java."""
 
-load("@bazel_skylib//lib:modules.bzl", "modules")
+load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "//java:repositories.bzl",
     "java_tools_repos",
@@ -24,7 +24,7 @@ load(
     "remote_jdk8_repos",
 )
 
-def _toolchains_impl():
+def _toolchains_impl(module_ctx):
     java_tools_repos()
     local_jdk_repo()
     remote_jdk8_repos()
@@ -32,4 +32,9 @@ def _toolchains_impl():
     remote_jdk17_repos()
     remote_jdk21_repos()
 
-toolchains = modules.as_extension(_toolchains_impl)
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    else:
+        return None
+
+toolchains = module_extension(_toolchains_impl)


### PR DESCRIPTION
The toolchain extension isn't internal to rules_java as users have to `use_extension` it to get a reference to `local_jdk`. They should not see a warning about not importing all the other repos, which comes with `modules.as_extension` due to its use of `use_all_repos`. Instead, just declare the extension as reproducible.