### PR TITLE
Remove @rules_cc//cc:defs.bzl references

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_cc", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.13")
 bazel_dep(name = "bazel_features", version = "1.11.0")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "protobuf", version = "27.0")

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load(
     ":default_java_toolchain.bzl",
     "DEFAULT_TOOLCHAIN_CONFIGURATION",

--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -14,7 +14,7 @@
 
 """Rules for defining default_java_toolchain"""
 
-load("//java:defs.bzl", "java_toolchain")
+load("//java/toolchains:java_toolchain.bzl", "java_toolchain")
 load("//java/common:java_common.bzl", "java_common")
 
 # JVM options, without patching java.compiler and jdk.compiler modules.

--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -14,8 +14,8 @@
 
 """Rules for defining default_java_toolchain"""
 
-load("//java/toolchains:java_toolchain.bzl", "java_toolchain")
 load("//java/common:java_common.bzl", "java_common")
+load("//java/toolchains:java_toolchain.bzl", "java_toolchain")
 
 # JVM options, without patching java.compiler and jdk.compiler modules.
 BASE_JDK9_JVM_OPTS = [

--- a/toolchains/jdk_build_file.bzl
+++ b/toolchains/jdk_build_file.bzl
@@ -14,7 +14,7 @@
 
 """A templated BUILD file for Java repositories."""
 
-JDK_BUILD_TEMPLATE = """load("@rules_java//java:defs.bzl", "java_runtime")
+JDK_BUILD_TEMPLATE = """load("@rules_java//java/toolchains:java_runtime.bzl", "java_runtime")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -14,7 +14,7 @@
 
 """Rules for importing a local JDK."""
 
-load("//java:defs.bzl", "java_runtime")
+load("//java/toolchains:java_runtime.bzl", "java_runtime")
 load(":default_java_toolchain.bzl", "default_java_toolchain")
 
 def _detect_java_version(repository_ctx, java_bin):


### PR DESCRIPTION
Referring to @rules_cc//cc:defs.bzl, refers to @protobuf//bazel:java_proto_library.bzl, which fetches protobuf repository.
Referring directly to what's needed limits the fetches just to rules_cc.