### PR TITLE
[7.x] Fix `auto_create_deploy_jars` in `java_binary` for IntelliJ

### DIFF
--- a/java/common/rules/impl/java_binary_impl.bzl
+++ b/java/common/rules/impl/java_binary_impl.bzl
@@ -447,7 +447,7 @@ def _auto_create_deploy_jar(ctx, info, launcher_info, main_class, coverage_main_
         resources = java_attrs.resources,
         classpath_resources = java_attrs.classpath_resources,
         runtime_classpath = runtime_classpath,
-        manifest_lines = info.manifest_lines,
+        manifest_lines = [],
         build_info_files = [],
         build_target = str(ctx.label),
         output = output,


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_java/issues/230

PiperOrigin-RevId: 683574444
Change-Id: I4d1fe8e90392c37cc873ad97f079c9f3d9b401d5 (cherry picked from commit 071069d0f20b1e39e11de5779947af366ac828c1)