### PR TITLE
Use hermetic Java runtimes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,10 @@
 common --incompatible_disallow_empty_glob
+
+# Use hermetic JDKs for testing and ensure compatibliity with Java 8.
+common --java_language_version=8
+common --java_runtime_version=remotejdk_8
+common --tool_java_language_version=8
+common --tool_java_runtime_version=remotejdk_8
+
+# Hide Java 8 deprecation warnings.
+common --javacopt=-Xlint:-options


### PR DESCRIPTION
Makes it easier to contribute to the project while ensuring that it remains compatible with Java 8.