### PR TITLE
Revert `bootstrap_runtime_toolchain_type` changes

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -120,12 +120,12 @@ tasks:
 # Bazel 6.x
   ubuntu2004_bazel6:
     name: "Bazel 6.x"
-    bazel: 6.3.0
+    bazel: 6.4.0
     platform: ubuntu2004
     build_targets: *build_targets_bazel6
   ubuntu2004_integration_bazel6:
     name: "Bazel 6.x Integration"
-    bazel: 6.3.0
+    bazel: 6.4.0
     platform: ubuntu2004
     working_directory: "test/repo"
     shell_commands:
@@ -137,11 +137,11 @@ tasks:
     - "//:MyTest"
   macos_bazel6:
     name: "Bazel 6.x"
-    bazel: 6.3.0
+    bazel: 6.4.0
     platform: macos
     build_targets: *build_targets_bazel6
   windows_bazel6:
     name: "Bazel 6.x"
-    bazel: 6.3.0
+    bazel: 6.4.0
     platform: windows
     build_targets: *build_targets_bazel6

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_java",
     version = "8.5.1",
-    bazel_compatibility = [">=6.3.0"],
+    bazel_compatibility = [">=6.4.0"],
     compatibility_level = 1,
 )
 

--- a/test/repo/BUILD.bazel
+++ b/test/repo/BUILD.bazel
@@ -26,4 +26,5 @@ java_test(
 
 default_java_toolchain(
     name = "my_funky_toolchain",
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
 )

--- a/test/repo/WORKSPACE
+++ b/test/repo/WORKSPACE
@@ -13,6 +13,8 @@ load("@com_google_protobuf//bazel/private:proto_bazel_features.bzl", "proto_baze
 
 proto_bazel_features(name = "proto_bazel_features")
 
+register_toolchains("//:all")
+
 load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
 
 rules_java_toolchains()

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -67,8 +67,8 @@ filegroup(
 #
 # Toolchains of this type are only consumed internally by the bootclasspath rule and should not be
 # accessed from Starlark.
-
-toolchain_type(name = "bootstrap_runtime_toolchain_type")
+# TODO: migrate away from using @bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type ?
+# toolchain_type(name = "bootstrap_runtime_toolchain_type")
 
 # Points to toolchain[":runtime_toolchain_type"] (was :legacy_current_java_runtime)
 java_runtime_alias(name = "current_java_runtime")

--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -213,7 +213,7 @@ def java_runtime_files(name, srcs):
             tags = ["manual"],
         )
 
-_JAVA_BOOTSTRAP_RUNTIME_TOOLCHAIN_TYPE = Label("//toolchains:bootstrap_runtime_toolchain_type")
+_JAVA_BOOTSTRAP_RUNTIME_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type")
 
 # Opt the Java bootstrap actions into path mapping:
 # https://github.com/bazelbuild/bazel/commit/a239ea84832f18ee8706682145e9595e71b39680

--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -110,7 +110,7 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
     native.toolchain(
         name = "bootstrap_runtime_toolchain_definition",
         target_settings = [":%s_settings_alias" % name],
-        toolchain_type = Label("//toolchains:bootstrap_runtime_toolchain_type"),
+        toolchain_type = Label("@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type"),
         toolchain = runtime_name,
     )
 
@@ -268,7 +268,7 @@ toolchain(
 toolchain(
    name = "bootstrap_runtime_toolchain_definition",
    target_settings = [":localjdk_setting"],
-   toolchain_type = "@rules_java//tools/jdk:bootstrap_runtime_toolchain_type",
+   toolchain_type = "@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type",
    toolchain = ":jdk",
 )
 '''

--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -268,7 +268,7 @@ toolchain(
 toolchain(
    name = "bootstrap_runtime_toolchain_definition",
    target_settings = [":localjdk_setting"],
-   toolchain_type = "@rules_java//toolchains:bootstrap_runtime_toolchain_type",
+   toolchain_type = "@rules_java//tools/jdk:bootstrap_runtime_toolchain_type",
    toolchain = ":jdk",
 )
 '''

--- a/toolchains/remote_java_repository.bzl
+++ b/toolchains/remote_java_repository.bzl
@@ -89,7 +89,7 @@ toolchain(
     # the same configuration, this constraint will not result in toolchain resolution failures.
     exec_compatible_with = {target_compatible_with},
     target_settings = [":version_or_prefix_version_setting"],
-    toolchain_type = "@rules_java//toolchains:bootstrap_runtime_toolchain_type",
+    toolchain_type = "@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type",
     toolchain = "{toolchain}",
 )
 """.format(


### PR DESCRIPTION
This reverts the relevant bits from bcc506228f3ac2c6a811c3414329d8727883685e and 30ecf3ff. The minimum supported Bazel version is now 6.4.0 which includes the type in `@bazel_tools`.