### PR TITLE
[7.x] Revert `bootstrap_runtime_toolchain_type` changes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_java",
     version = "7.12.2",
-    bazel_compatibility = [">=6.2.0"],
+    bazel_compatibility = [">=6.4.0"],
     compatibility_level = 1,
 )
 

--- a/test/repo/BUILD.bazel
+++ b/test/repo/BUILD.bazel
@@ -14,4 +14,5 @@ java_binary(
 
 default_java_toolchain(
     name = "my_funky_toolchain",
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],
 )

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -66,8 +66,8 @@ filegroup(
 #
 # Toolchains of this type are only consumed internally by the bootclasspath rule and should not be
 # accessed from Starlark.
-
-toolchain_type(name = "bootstrap_runtime_toolchain_type")
+# TODO: migrate away from using @bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type ?
+# toolchain_type(name = "bootstrap_runtime_toolchain_type")
 
 # Points to toolchain[":runtime_toolchain_type"] (was :legacy_current_java_runtime)
 java_runtime_alias(name = "current_java_runtime")

--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -211,7 +211,7 @@ def java_runtime_files(name, srcs):
             tags = ["manual"],
         )
 
-_JAVA_BOOTSTRAP_RUNTIME_TOOLCHAIN_TYPE = Label("//toolchains:bootstrap_runtime_toolchain_type")
+_JAVA_BOOTSTRAP_RUNTIME_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type")
 
 # Opt the Java bootstrap actions into path mapping:
 # https://github.com/bazelbuild/bazel/commit/a239ea84832f18ee8706682145e9595e71b39680

--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -110,7 +110,7 @@ def local_java_runtime(name, java_home, version, runtime_name = None, visibility
     native.toolchain(
         name = "bootstrap_runtime_toolchain_definition",
         target_settings = [":%s_settings_alias" % name],
-        toolchain_type = Label("//toolchains:bootstrap_runtime_toolchain_type"),
+        toolchain_type = Label("@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type"),
         toolchain = runtime_name,
     )
 
@@ -268,7 +268,7 @@ toolchain(
 toolchain(
    name = "bootstrap_runtime_toolchain_definition",
    target_settings = [":localjdk_setting"],
-   toolchain_type = "@rules_java//toolchains:bootstrap_runtime_toolchain_type",
+   toolchain_type = "@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type",
    toolchain = ":jdk",
 )
 '''

--- a/toolchains/remote_java_repository.bzl
+++ b/toolchains/remote_java_repository.bzl
@@ -89,7 +89,7 @@ toolchain(
     # the same configuration, this constraint will not result in toolchain resolution failures.
     exec_compatible_with = {target_compatible_with},
     target_settings = [":version_or_prefix_version_setting"],
-    toolchain_type = "@rules_java//toolchains:bootstrap_runtime_toolchain_type",
+    toolchain_type = "@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type",
     toolchain = "{toolchain}",
 )
 """.format(


### PR DESCRIPTION
Copybara Import from https://github.com/bazelbuild/rules_java/pull/246

BEGIN_PUBLIC
Revert `bootstrap_runtime_toolchain_type` changes (#246)

This reverts the relevant bits from bcc506228f3ac2c6a811c3414329d8727883685e and 30ecf3ff. The minimum supported Bazel version is now 6.4.0 which includes the type in `@bazel_tools`.

Closes #246
END_PUBLIC

COPYBARA_INTEGRATE_REVIEW=https://github.com/bazelbuild/rules_java/pull/246 from bazelbuild:hvd_tests_for_bootclasspath b666dc289edac950f006b81452193a4dcc91592a PiperOrigin-RevId: 702260069
Change-Id: Ie64994873a7b5609d4fb8b12a2472c82eb71493b

(cherry picked from commit 4206c536c77c4f1ec9a918987d31a3c528e5c0b4)

Conflicts:
  .bazelci/presubmit.yml
  MODULE.bazel
  test/repo/WORKSPACE