### PR TITLE
[7.x] Remove `load()`s of `//java:defs.bzl`

### DIFF
--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -14,8 +14,8 @@
 
 """Rules for defining default_java_toolchain"""
 
-load("//java:defs.bzl", "java_toolchain")
 load("//java/common:java_common.bzl", "java_common")
+load("//java/toolchains:java_toolchain.bzl", "java_toolchain")
 
 # JVM options, without patching java.compiler and jdk.compiler modules.
 BASE_JDK9_JVM_OPTS = [

--- a/toolchains/jdk_build_file.bzl
+++ b/toolchains/jdk_build_file.bzl
@@ -14,7 +14,7 @@
 
 """A templated BUILD file for Java repositories."""
 
-JDK_BUILD_TEMPLATE = """load("@rules_java//java:defs.bzl", "java_runtime")
+JDK_BUILD_TEMPLATE = """load("@rules_java//java/toolchains:java_runtime.bzl", "java_runtime")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -14,7 +14,7 @@
 
 """Rules for importing a local JDK."""
 
-load("//java:defs.bzl", "java_runtime")
+load("//java/toolchains:java_runtime.bzl", "java_runtime")
 load(":default_java_toolchain.bzl", "default_java_toolchain")
 
 def _detect_java_version(repository_ctx, java_bin):


### PR DESCRIPTION
This should make it possible to pin `@rules_java` to `7.x` with Bazel 8 in projects that don't actually require/use `@rules_java`.

Otherwise, the `register_toolchains()` call in `MODULE.bazel` fails with Bazel 8 due to `native.java_proto_library` and `native.java_lite_proto_library` in `defs.bzl`