### PR TITLE
Add JDK 21 toolchain for `linux_riscv64`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -72,6 +72,7 @@ JDKS = {
         "linux",
         "linux_aarch64",
         "linux_ppc64le",
+        "linux_riscv64",
         "linux_s390x",
         "macos",
         "macos_aarch64",

--- a/java/bazel/repositories_util.bzl
+++ b/java/bazel/repositories_util.bzl
@@ -82,7 +82,7 @@ _RELEASE_CONFIGS = {
         "adoptium": {
             "release": "21.0.4+7",
             "platforms": {
-                "linux": ["ppc", "s390x"],
+                "linux": ["ppc", "riscv64", "s390x"],
             },
         },
     },

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -311,6 +311,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
         version = "21",
     ),
     struct(
+        name = "remotejdk21_linux_riscv64",
+        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:riscv64"],
+        sha256 = "b04fd7f52d18268a935f1a7144dae802b25db600ec97156ddd46b3100cbd13da",
+        strip_prefix = "jdk-21.0.4+7",
+        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.4_7.tar.gz", "https://mirror.bazel.build/github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.4_7.tar.gz"],
+        version = "21",
+    ),
+    struct(
         name = "remotejdk21_linux_s390x",
         target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:s390x"],
         sha256 = "c900c8d64fab1e53274974fa4a4c736a5a3754485a5c56f4947281480773658a",

--- a/test/repo/MODULE.bazel
+++ b/test/repo/MODULE.bazel
@@ -37,6 +37,7 @@ use_repo(
     "remotejdk17_win",
     "remotejdk17_win_arm64",
     "remotejdk21_linux",
+    "remotejdk21_linux_riscv64",
     "remotejdk21_macos",
     "remotejdk21_macos_aarch64",
     "remotejdk21_win",


### PR DESCRIPTION
A Googler will need to help add the mirror for Adoptium Temurin's 21.0.4+7 JDK release for `linux_riscv64`
* https://bazel.googlesource.com/continuous-integration/+/refs/heads/master/docs/mirror.md