### PR TITLE
Add make variables for runfiles location of $(JAVABASE) to support --no_legacy_external_runfiles.

### DIFF
--- a/java/common/rules/java_runtime.bzl
+++ b/java/common/rules/java_runtime.bzl
@@ -152,7 +152,8 @@ def _java_runtime_rule_impl(ctx):
         platform_common.TemplateVariableInfo({
             "JAVA": java_binary_exec_path,
             "JAVABASE": java_home,
-            "JAVABASE_RUNFILES": java_home_runfiles_path,
+            "JAVA_ROOTPATH": paths.join(java_home_runfiles_path, "bin/java"),
+            "JAVABASE_ROOTPATH": java_home_runfiles_path,
         }),
         ToolchainInfo(java_runtime = java_runtime_info),
     ]

--- a/java/common/rules/java_runtime.bzl
+++ b/java/common/rules/java_runtime.bzl
@@ -152,7 +152,7 @@ def _java_runtime_rule_impl(ctx):
         platform_common.TemplateVariableInfo({
             "JAVA": java_binary_exec_path,
             "JAVABASE": java_home,
-            "JAVA_ROOTPATH": paths.join(java_home_runfiles_path, "bin/java"),
+            "JAVA_ROOTPATH": java_binary_runfiles_path,
             "JAVABASE_ROOTPATH": java_home_runfiles_path,
         }),
         ToolchainInfo(java_runtime = java_runtime_info),

--- a/java/common/rules/java_runtime.bzl
+++ b/java/common/rules/java_runtime.bzl
@@ -152,6 +152,8 @@ def _java_runtime_rule_impl(ctx):
         platform_common.TemplateVariableInfo({
             "JAVA": java_binary_exec_path,
             "JAVABASE": java_home,
+            "JAVA_RUNFILES": java_binary_runfiles_path,
+            "JAVABASE_RUNFILES": java_home_runfiles_path,
         }),
         ToolchainInfo(java_runtime = java_runtime_info),
     ]

--- a/java/common/rules/java_runtime.bzl
+++ b/java/common/rules/java_runtime.bzl
@@ -152,7 +152,6 @@ def _java_runtime_rule_impl(ctx):
         platform_common.TemplateVariableInfo({
             "JAVA": java_binary_exec_path,
             "JAVABASE": java_home,
-            "JAVA_RUNFILES": java_binary_runfiles_path,
             "JAVABASE_RUNFILES": java_home_runfiles_path,
         }),
         ToolchainInfo(java_runtime = java_runtime_info),

--- a/test/repo/BUILD.bazel
+++ b/test/repo/BUILD.bazel
@@ -24,6 +24,28 @@ java_test(
     ],
 )
 
+genrule(
+    name = "MakeVarGenruleTest",
+    outs = ["success"],
+    cmd = "test -f $(JAVA) && test -d $(JAVABASE) && touch $@",
+    toolchains = ["@rules_java//toolchains:current_java_runtime"],
+    tools = ["@rules_java//toolchains:current_java_runtime"],
+)
+
+sh_test(
+    name = "MakeVarTest",
+    srcs = ["src/MakeVarTest.sh"],
+    data = [
+        "success",
+        "@rules_java//toolchains:current_java_runtime",
+    ],
+    env = {
+        "JAVA_RUNFILES": "$(JAVA_RUNFILES)",
+        "JAVABASE_RUNFILES": "$(JAVABASE_RUNFILES)",
+    },
+    toolchains = ["@rules_java//toolchains:current_java_runtime"],
+)
+
 default_java_toolchain(
     name = "my_funky_toolchain",
     bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath"],

--- a/test/repo/BUILD.bazel
+++ b/test/repo/BUILD.bazel
@@ -27,7 +27,7 @@ java_test(
 
 genrule(
     name = "MakeVarGenruleTest",
-    outs = ["success"],
+    outs = ["MakeVarGenruleTestSuccess"],
     cmd = "test -f $(JAVA) && test -d $(JAVABASE) && touch $@",
     toolchains = ["@rules_java//toolchains:current_java_runtime"],
     tools = ["@rules_java//toolchains:current_java_runtime"],
@@ -37,11 +37,12 @@ sh_test(
     name = "MakeVarTest",
     srcs = ["src/MakeVarTest.sh"],
     data = [
-        "success",
+        "MakeVarGenruleTestSuccess",
         "@rules_java//toolchains:current_java_runtime",
     ],
     env = {
-        "JAVABASE_RUNFILES": "$(JAVABASE_RUNFILES)",
+        "JAVA_ROOTPATH": "$(JAVA_ROOTPATH)",
+        "JAVABASE_ROOTPATH": "$(JAVABASE_ROOTPATH)",
     },
     toolchains = ["@rules_java//toolchains:current_java_runtime"],
 )

--- a/test/repo/BUILD.bazel
+++ b/test/repo/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")  # copybara-use-repo-external-label
 load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")  # copybara-use-repo-external-label
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 java_library(
     name = "lib",

--- a/test/repo/BUILD.bazel
+++ b/test/repo/BUILD.bazel
@@ -40,7 +40,6 @@ sh_test(
         "@rules_java//toolchains:current_java_runtime",
     ],
     env = {
-        "JAVA_RUNFILES": "$(JAVA_RUNFILES)",
         "JAVABASE_RUNFILES": "$(JAVABASE_RUNFILES)",
     },
     toolchains = ["@rules_java//toolchains:current_java_runtime"],

--- a/test/repo/MODULE.bazel
+++ b/test/repo/MODULE.bazel
@@ -44,3 +44,5 @@ use_repo(
 )
 
 register_toolchains("//:all")
+
+bazel_dep(name = "rules_shell", version = "0.4.0")

--- a/test/repo/WORKSPACE
+++ b/test/repo/WORKSPACE
@@ -25,3 +25,18 @@ http_jar(
     name = "my_jar",
     urls = ["file:///tmp/my_jar.jar"],
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_shell",
+    sha256 = "3e114424a5c7e4fd43e0133cc6ecdfe54e45ae8affa14fadd839f29901424043",
+    strip_prefix = "rules_shell-0.4.0",
+    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.4.0/rules_shell-v0.4.0.tar.gz",
+)
+
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()

--- a/test/repo/src/MakeVarTest.sh
+++ b/test/repo/src/MakeVarTest.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
-if [ ! -f "$JAVABASE_RUNFILES/bin/java" ]; then
+if [ ! -x "$JAVABASE_ROOTPATH/bin/java" ]; then
   echo '$JAVABASE_RUNFILES does not point to a working JRE' && exit 1
+fi
+
+echo $JAVA_ROOTPATH
+if [ ! -x "$JAVA_ROOTPATH" ]; then
+  echo '$JAVA_ROOTPATH does not exist' && exit 1
 fi

--- a/test/repo/src/MakeVarTest.sh
+++ b/test/repo/src/MakeVarTest.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-test -d "$JAVABASE_RUNFILES" || (echo 'JAVABASE_RUNFILES not found' && exit 1)
-test -f "$JAVA_RUNFILES" || (echo 'JAVA_RUNFILES not found' && exit 1)
+if [ ! -f "$JAVABASE_RUNFILES/bin/java" ]; then
+  echo '$JAVABASE_RUNFILES does not point to a working JRE' && exit 1
+fi

--- a/test/repo/src/MakeVarTest.sh
+++ b/test/repo/src/MakeVarTest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+test -d "$JAVABASE_RUNFILES" || (echo 'JAVABASE_RUNFILES not found' && exit 1)
+test -f "$JAVA_RUNFILES" || (echo 'JAVA_RUNFILES not found' && exit 1)

--- a/toolchains/java_toolchain_alias.bzl
+++ b/toolchains/java_toolchain_alias.bzl
@@ -26,6 +26,8 @@ def _java_runtime_alias(ctx):
         platform_common.TemplateVariableInfo({
             "JAVA": str(toolchain.java_executable_exec_path),
             "JAVABASE": str(toolchain.java_home),
+            "JAVA_RUNFILES": str(toolchain.java_executable_runfiles_path),
+            "JAVABASE_RUNFILES": str(toolchain.java_home_runfiles_path),
         }),
         # See b/65239471 for related discussion of handling toolchain runfiles/data.
         DefaultInfo(

--- a/toolchains/java_toolchain_alias.bzl
+++ b/toolchains/java_toolchain_alias.bzl
@@ -14,7 +14,6 @@
 
 """Experimental re-implementations of Java toolchain aliases using toolchain resolution."""
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//java/common:java_common.bzl", "java_common")
 
 def _java_runtime_alias(ctx):
@@ -27,7 +26,7 @@ def _java_runtime_alias(ctx):
         platform_common.TemplateVariableInfo({
             "JAVA": str(toolchain.java_executable_exec_path),
             "JAVABASE": str(toolchain.java_home),
-            "JAVA_ROOTPATH": paths.join(toolchain.java_home_runfiles_path, "bin/java"),
+            "JAVA_ROOTPATH": str(toolchain.java_executable_runfiles_path),
             "JAVABASE_ROOTPATH": str(toolchain.java_home_runfiles_path),
         }),
         # See b/65239471 for related discussion of handling toolchain runfiles/data.

--- a/toolchains/java_toolchain_alias.bzl
+++ b/toolchains/java_toolchain_alias.bzl
@@ -14,6 +14,7 @@
 
 """Experimental re-implementations of Java toolchain aliases using toolchain resolution."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//java/common:java_common.bzl", "java_common")
 
 def _java_runtime_alias(ctx):
@@ -26,7 +27,8 @@ def _java_runtime_alias(ctx):
         platform_common.TemplateVariableInfo({
             "JAVA": str(toolchain.java_executable_exec_path),
             "JAVABASE": str(toolchain.java_home),
-            "JAVABASE_RUNFILES": str(toolchain.java_home_runfiles_path),
+            "JAVA_ROOTPATH": paths.join(toolchain.java_home_runfiles_path, "bin/java"),
+            "JAVABASE_ROOTPATH": str(toolchain.java_home_runfiles_path),
         }),
         # See b/65239471 for related discussion of handling toolchain runfiles/data.
         DefaultInfo(

--- a/toolchains/java_toolchain_alias.bzl
+++ b/toolchains/java_toolchain_alias.bzl
@@ -26,7 +26,6 @@ def _java_runtime_alias(ctx):
         platform_common.TemplateVariableInfo({
             "JAVA": str(toolchain.java_executable_exec_path),
             "JAVABASE": str(toolchain.java_home),
-            "JAVA_RUNFILES": str(toolchain.java_executable_runfiles_path),
             "JAVABASE_RUNFILES": str(toolchain.java_home_runfiles_path),
         }),
         # See b/65239471 for related discussion of handling toolchain runfiles/data.


### PR DESCRIPTION
Add make variables for runfiles locations of `$(JAVA)` and `$(JAVABASE)`. These are needed to access these paths when passing them to test rules via `env` when using `--no_legacy_external_runfiles`. The original make variables still work in exec contexts such as genrules.