### PR TITLE
Set use_default_shell_env = True consistently.

### DIFF
--- a/java/common/rules/android_lint.bzl
+++ b/java/common/rules/android_lint.bzl
@@ -136,6 +136,7 @@ def _android_lint_action(ctx, source_files, source_jars, compilation_info):
         tools = tools,
         arguments = args_list,
         execution_requirements = {"supports-workers": "1"},
+        use_default_shell_env = True,
     )
     return android_lint_out
 

--- a/java/common/rules/impl/import_deps_check.bzl
+++ b/java/common/rules/impl/import_deps_check.bzl
@@ -76,6 +76,7 @@ def import_deps_check(
         outputs = [jdeps_output],
         tools = tools,
         toolchain = semantics.JAVA_TOOLCHAIN_TYPE,
+        use_default_shell_env = True,
     )
 
     return jdeps_output

--- a/java/common/rules/impl/java_binary_impl.bzl
+++ b/java/common/rules/impl/java_binary_impl.bzl
@@ -361,6 +361,7 @@ def _create_one_version_check(ctx, inputs, is_test_rule_class):
         tools = [tool],
         outputs = [output],
         arguments = [args],
+        use_default_shell_env = True,
     )
 
     return output

--- a/java/common/rules/impl/java_helper.bzl
+++ b/java/common/rules/impl/java_helper.bzl
@@ -366,6 +366,7 @@ def _create_single_jar(
         tools = [toolchain.single_jar],
         outputs = [output],
         arguments = [args],
+        use_default_shell_env = True,
     )
     return output
 

--- a/java/common/rules/impl/proguard_validation.bzl
+++ b/java/common/rules/impl/proguard_validation.bzl
@@ -43,6 +43,7 @@ def _validate_spec(ctx, spec_file):
         inputs = [spec_file],
         outputs = [validated_proguard_spec],
         toolchain = Label(semantics.JAVA_TOOLCHAIN_TYPE),
+        use_default_shell_env = True,
     )
 
     return validated_proguard_spec

--- a/java/java_single_jar.bzl
+++ b/java/java_single_jar.bzl
@@ -62,6 +62,7 @@ def _java_single_jar(ctx):
         progress_message = "Merging into %s" % ctx.outputs.jar.short_path,
         mnemonic = "JavaSingleJar",
         executable = ctx.executable._singlejar,
+        use_default_shell_env = True,
     )
 
     files = depset([ctx.outputs.jar])

--- a/toolchains/bootclasspath.bzl
+++ b/toolchains/bootclasspath.bzl
@@ -135,6 +135,7 @@ def _bootclasspath_impl(ctx):
         arguments = [args],
         env = env,
         execution_requirements = _SUPPORTS_PATH_MAPPING,
+        use_default_shell_env = True,
     )
 
     bootclasspath = ctx.outputs.output_jar
@@ -202,6 +203,7 @@ Rerun with --toolchain_resolution_debug='@bazel_tools//tools/jdk:bootstrap_runti
         arguments = [args],
         env = env,
         execution_requirements = _SUPPORTS_PATH_MAPPING,
+        use_default_shell_env = True,
     )
     return [
         DefaultInfo(files = depset([bootclasspath])),


### PR DESCRIPTION
About half the action registrations in rules_java formerly set this. Be consistent.