### PR TITLE
[7.x] Add JDK 21 toolchain for `linux_riscv64`

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,7 +18,7 @@ build_targets_bzlmod: &build_targets_bzlmod
 test_targets: &test_targets
   - "//test/..."
 
-buildifier: latest
+buildifier: 7.3.1
 
 tasks:
 # TODO: add config for 8.0.0 once released

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -72,6 +72,7 @@ JDKS = {
         "linux",
         "linux_aarch64",
         "linux_ppc64le",
+        "linux_riscv64",
         "linux_s390x",
         "macos",
         "macos_aarch64",

--- a/java/bazel/repositories_util.bzl
+++ b/java/bazel/repositories_util.bzl
@@ -82,7 +82,7 @@ _RELEASE_CONFIGS = {
         "adoptium": {
             "release": "21.0.4+7",
             "platforms": {
-                "linux": ["ppc", "s390x"],
+                "linux": ["ppc", "riscv64", "s390x"],
             },
         },
     },

--- a/java/repositories.bzl
+++ b/java/repositories.bzl
@@ -309,6 +309,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
         version = "21",
     ),
     struct(
+        name = "remotejdk21_linux_riscv64",
+        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:riscv64"],
+        sha256 = "b04fd7f52d18268a935f1a7144dae802b25db600ec97156ddd46b3100cbd13da",
+        strip_prefix = "jdk-21.0.4+7",
+        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.4_7.tar.gz", "https://mirror.bazel.build/github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.4+7/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.4_7.tar.gz"],
+        version = "21",
+    ),
+    struct(
         name = "remotejdk21_linux_s390x",
         target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:s390x"],
         sha256 = "c900c8d64fab1e53274974fa4a4c736a5a3754485a5c56f4947281480773658a",

--- a/test/repo/MODULE.bazel
+++ b/test/repo/MODULE.bazel
@@ -30,6 +30,7 @@ use_repo(
     "remotejdk17_win",
     "remotejdk17_win_arm64",
     "remotejdk21_linux",
+    "remotejdk21_linux_riscv64",
     "remotejdk21_macos",
     "remotejdk21_macos_aarch64",
     "remotejdk21_win",


### PR DESCRIPTION
This is a cherry-pick of #258 into 7.x.

A new release would be appreciated as building bazel 7.x on riscv64 would require this.
