### PR TITLE
Increase maxwarns to -1

### DIFF
--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -49,10 +49,6 @@ BASE_JDK9_JVM_OPTS = [
     # makes it go to stderr instead.
     "-Xlog:disable",
     "-Xlog:all=warning:stderr:uptime,level,tags",
-
-    # Please see https://github.com/bazelbuild/bazel/issues/25927#issuecomment-2825206105
-    # we need to make sure not to filter any warnings so that Bazel can trigger them as errors.
-    "-Xmaxwarns -1",
 ]
 
 JDK9_JVM_OPTS = BASE_JDK9_JVM_OPTS
@@ -71,6 +67,9 @@ DEFAULT_JAVACOPTS = [
     "-Xep:LenientFormatStringValidation:OFF",
     "-Xep:ReturnMissingNullable:OFF",
     "-Xep:UseCorrectAssertInTests:OFF",
+    # Please see https://github.com/bazelbuild/bazel/issues/25927#issuecomment-2825206105
+    # we need to make sure not to filter any warnings so that Bazel can trigger them as errors.
+    "-Xmaxwarns -1",
 ]
 
 # If this is changed, the docs for "{,tool_}java_language_version" also


### PR DESCRIPTION
Please see https://github.com/bazelbuild/bazel/issues/25927#issuecomment-2825206105

It's important not to filter out any warnings otherwise the lint warnings are not surfaced and then any attempt to do `-Werror` can fail with what may be observed as spurious (affect other parts of the codebase).

This is maybe a "breaking change" only if someone has enabled `-Werror` and may now see additional errors -- although that was in fact their intention...