### PR TITLE
Use the `launcher_maker` toolchain if available

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -42,6 +42,7 @@ test_target_integration: &test_target_integration
 flags_workspace_integration: &flags_workspace_integration
   - "--noenable_bzlmod"
   - "--enable_workspace"
+  - "--repositories_without_autoloads=bazel_features_version,bazel_features_globals"
 
 buildifier: latest
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -58,22 +58,30 @@ tasks:
     bazel: "7.6.1"
     platform: ${{ all_platforms }}
     build_targets: *build_targets
+    build_flags:
+      - "--build_tag_filters=-min_bazel_8,-min_bazel_9"
     test_targets: *test_targets
     test_flags:
       - "--test_tag_filters=-min_bazel_8,-min_bazel_9"
-# Bazel 8+
+# Bazel 8.x
   build_and_test:
     name: "Bazel {modern_bazel}"
     bazel: ${{ modern_bazel }}
     platform: ${{ all_platforms }}
     build_targets: *build_targets
+    build_flags:
+      - "--build_tag_filters=-min_bazel_9"
     test_targets: *test_targets
+    test_flags:
+      - "--test_tag_filters=-min_bazel_9"
 # Bazel 6.x
   build_and_test_bazel6:
     name: "Bazel 6.5.0"
     bazel: 6.5.0
     platform: ${{ all_platforms }}
     build_targets: *build_targets_bazel6
+    build_flags:
+      - "--build_tag_filters=-min_bazel_7,-min_bazel_8,-min_bazel_9"
     test_targets: *test_targets_bazel6
     test_flags:
       - "--test_tag_filters=-min_bazel_7,-min_bazel_8,-min_bazel_9"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -60,7 +60,7 @@ tasks:
     build_targets: *build_targets
     test_targets: *test_targets
     test_flags:
-      - "--test_tag_filters=-min_bazel_8"
+      - "--test_tag_filters=-min_bazel_8,-min_bazel_9"
 # Bazel 8+
   build_and_test:
     name: "Bazel {modern_bazel}"
@@ -76,7 +76,7 @@ tasks:
     build_targets: *build_targets_bazel6
     test_targets: *test_targets_bazel6
     test_flags:
-      - "--test_tag_filters=-min_bazel_7,-min_bazel_8"
+      - "--test_tag_filters=-min_bazel_7,-min_bazel_8,-min_bazel_9"
   ubuntu2004_integration_bazel6:
     name: "Integration w/ Bazel 6.5.0"
     bazel: 6.5.0

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,14 +7,7 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_cc", version = "0.0.15")
-bazel_dep(name = "bazel_features", version = "1.28.0")
-archive_override(
-    module_name = "bazel_features",
-    integrity = "sha256-SOPLvKDy+RN7GHKN8eFjQ+58Wx4Isj+vcXoUluBqxLo=",
-    strip_prefix = "bazel_features-59915eb2ca215c7b2266c83c49bb7522a5b6737f",
-    urls = ["https://github.com/bazel-contrib/bazel_features/archive/59915eb2ca215c7b2266c83c49bb7522a5b6737f.zip"],
-)
-
+bazel_dep(name = "bazel_features", version = "1.30.0")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -74,7 +74,3 @@ http_archive(
     strip_prefix = "bazel_features-59915eb2ca215c7b2266c83c49bb7522a5b6737f",
     url = "https://github.com/bazel-contrib/bazel_features/archive/59915eb2ca215c7b2266c83c49bb7522a5b6737f.zip",
 )
-
-load("@bazel_features//:deps.bzl", "bazel_features_deps")
-
-bazel_features_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,10 +67,3 @@ http_archive(
 load("//test:repositories.bzl", "test_repositories")
 
 test_repositories()
-
-http_archive(
-    name = "bazel_features",
-    sha256 = "48e3cbbca0f2f9137b18728df1e16343ee7c5b1e08b23faf717a1496e06ac4ba",
-    strip_prefix = "bazel_features-59915eb2ca215c7b2266c83c49bb7522a5b6737f",
-    url = "https://github.com/bazel-contrib/bazel_features/archive/59915eb2ca215c7b2266c83c49bb7522a5b6737f.zip",
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,6 +41,10 @@ load("//java:rules_java_deps.bzl", "rules_java_dependencies")
 
 rules_java_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("@com_google_protobuf//bazel/private:proto_bazel_features.bzl", "proto_bazel_features")  # buildifier: disable=bzl-visibility
 
 proto_bazel_features(name = "proto_bazel_features")

--- a/distro/relnotes.bzl
+++ b/distro/relnotes.bzl
@@ -18,6 +18,16 @@ bazel_dep(name = "rules_java", version = "{VERSION}")
 ~~~
 
 **WORKSPACE setup**
+
+With Bazel 8.0.0 and before 8.3.0, add the following to your `.bazelrc` file:
+
+~~~
+# https://github.com/bazelbuild/bazel/pull/26119
+common --repositories_without_autoloads=bazel_features_version,bazel_features_globals
+~~~
+
+In all cases, add the following to your `WORKSPACE` file:
+
 ~~~
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(

--- a/distro/relnotes.bzl
+++ b/distro/relnotes.bzl
@@ -31,6 +31,9 @@ http_archive(
 load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
 rules_java_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+bazel_features_deps()
+
 # note that the following line is what is minimally required from protobuf for the java rules
 # consider using the protobuf_deps() public API from @com_google_protobuf//:protobuf_deps.bzl
 load("@com_google_protobuf//bazel/private:proto_bazel_features.bzl", "proto_bazel_features")  # buildifier: disable=bzl-visibility

--- a/java/bazel/rules/bazel_java_binary.bzl
+++ b/java/bazel/rules/bazel_java_binary.bzl
@@ -296,6 +296,7 @@ def _create_windows_exe_launcher(ctx, java_executable, classpath, main_class, jv
         outputs = [executable],
         arguments = [launcher_artifact.path, launch_info, executable.path],
         use_default_shell_env = True,
+        toolchain = _LAUNCHER_MAKER_TOOLCHAIN_TYPE if bazel_features.rules._has_launcher_maker_toolchain else None,
     )
     return executable
 

--- a/java/rules_java_deps.bzl
+++ b/java/rules_java_deps.bzl
@@ -210,6 +210,15 @@ def rules_license_repo():
         ],
     )
 
+def bazel_features_repo():
+    maybe(
+        http_archive,
+        name = "bazel_features",
+        sha256 = "a660027f5a87f13224ab54b8dc6e191693c554f2692fcca46e8e29ee7dabc43b",
+        strip_prefix = "bazel_features-1.30.0",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz",
+    )
+
 def rules_java_dependencies():
     """An utility method to load non-toolchain dependencies of rules_java.
 
@@ -223,3 +232,4 @@ def rules_java_dependencies():
     zlib_repo()
     absl_repo()
     rules_license_repo()
+    bazel_features_repo()

--- a/test/java/common/rules/java_binary_tests.bzl
+++ b/test/java/common/rules/java_binary_tests.bzl
@@ -171,6 +171,45 @@ def _test_java_binary_propagates_direct_native_libraries_impl(env, target):
         matching.str_matches("-Djava.library.path=${JAVA_RUNFILES}/*/test_java_binary_propagates_direct_native_libraries"),
     )
 
+def _test_java_binary_cross_compilation_to_unix(name):
+    # A Unix platform that:
+    # - has a JDK
+    # - does not require a launcher
+    # - is not supported by the default C++ toolchain
+    util.helper_target(
+        native.platform,
+        name = name + "/platform",
+        constraint_values = [
+            "@platforms//os:linux",
+            "@platforms//cpu:s390x",
+        ],
+    )
+
+    util.helper_target(
+        java_binary,
+        name = name + "/bin",
+        srcs = ["java/C.java"],
+        main_class = "C",
+    )
+
+    analysis_test(
+        name = name,
+        impl = _test_java_binary_cross_compilation_to_unix_impl,
+        target = name + "/bin",
+        config_settings = {
+            "//command_line_option:platforms": [Label(name + "/platform")],
+        },
+        # Requires the launcher_maker toolchain.
+        attr_values = {"tags": ["min_bazel_9"]},
+    )
+
+def _test_java_binary_cross_compilation_to_unix_impl(env, target):
+    # The main assertion is that analysis succeeds, but verify the absence of a
+    # binary launcher for good measure.
+    executable = target[DefaultInfo].files_to_run.executable.short_path
+    assert_action = env.expect.that_target(target).action_generating(executable)
+    assert_action.substitutions().keys().contains("%jvm_flags%")
+
 def java_binary_tests(name):
     test_suite(
         name = name,
@@ -179,5 +218,6 @@ def java_binary_tests(name):
             _test_stamp_conversion_does_not_override_int,
             _test_java_binary_attributes,
             _test_java_binary_propagates_direct_native_libraries,
+            _test_java_binary_cross_compilation_to_unix,
         ],
     )

--- a/test/repo/.bazelrc
+++ b/test/repo/.bazelrc
@@ -1,7 +1,10 @@
-build:bzlmod --experimental_enable_bzlmod
+build:bzlmod --enable_bzlmod
 
 common --incompatible_disallow_empty_glob
 
 # Enable modern C++ features, for compiling java_tools from source
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+
+# https://github.com/bazelbuild/bazel/pull/26119
+common --repositories_without_autoloads=bazel_features_version,bazel_features_globals

--- a/test/repo/.bazelrc
+++ b/test/repo/.bazelrc
@@ -1,10 +1,7 @@
-build:bzlmod --enable_bzlmod
+build:bzlmod --experimental_enable_bzlmod
 
 common --incompatible_disallow_empty_glob
 
 # Enable modern C++ features, for compiling java_tools from source
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
-
-# https://github.com/bazelbuild/bazel/pull/26119
-common --repositories_without_autoloads=bazel_features_version,bazel_features_globals

--- a/test/repo/WORKSPACE
+++ b/test/repo/WORKSPACE
@@ -9,6 +9,10 @@ load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
 
 rules_java_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("@com_google_protobuf//bazel/private:proto_bazel_features.bzl", "proto_bazel_features")  # buildifier: disable=bzl-visibility
 
 proto_bazel_features(name = "proto_bazel_features")


### PR DESCRIPTION
This avoids an unnecessary dependency on a C++ toolchain matching the target platform when not building for Windows.

Also fix the configuration of the launcher, which should be built for the target platform.