### PR TITLE
Make `java_toolchain` usable with `genrule`

### DIFF
--- a/java/common/rules/java_toolchain.bzl
+++ b/java/common/rules/java_toolchain.bzl
@@ -139,7 +139,14 @@ def _java_toolchain_impl(ctx):
         _timezone_data = ctx.file.timezone_data,
     )
     toolchain_info = ToolchainInfo(java = java_toolchain_info)
-    return [java_toolchain_info, toolchain_info, DefaultInfo()]
+    providers = [java_toolchain_info, toolchain_info]
+    if ctx.attr.java_runtime:
+        providers.append(ctx.attr.java_runtime[DefaultInfo])
+        if platform_common.TemplateVariableInfo in ctx.attr.java_runtime:
+            providers.append(ctx.attr.java_runtime[platform_common.TemplateVariableInfo])
+    else:
+        providers.append(DefaultInfo())
+    return providers
 
 def _get_bootclasspath_info(ctx):
     bootclasspath_infos = [dep[BootClassPathInfo] for dep in ctx.attr.bootclasspath if BootClassPathInfo in dep]


### PR DESCRIPTION
`genrule` accepts toolchain types since https://github.com/bazelbuild/bazel/commit/0e876b1794d4db58b72949014401d22cc65d94a1, but there is no way to get an exec-configured Java runtime in this way since `java_runtime` toolchains typically match on the target rather than the exec platform.

Instead, the `java_toolchain` used for compilation is made usable for this purpose by forwarding the `DefaultInfo` and `TemplateVariableInfo` of its `java_runtime`.