### PR TITLE
Set exec_compatible_with for the runtime Java toolchain

### DIFF
--- a/toolchains/remote_java_repository.bzl
+++ b/toolchains/remote_java_repository.bzl
@@ -77,7 +77,7 @@ alias(
 )
 toolchain(
     name = "toolchain",
-    target_compatible_with = {target_compatible_with},
+    exec_compatible_with = {target_compatible_with},
     target_settings = [":version_or_prefix_version_setting"],
     toolchain_type = "@bazel_tools//tools/jdk:runtime_toolchain_type",
     toolchain = "{toolchain}",


### PR DESCRIPTION
The bootstrap toolchain is already configured this way, and we want to express compatibility with the execution platform (where Bazel is executing build actions), rather than with the target platform.

This allows for using Bazel's --platforms flag to control the target platform for a build including Java targets, without having the Java toolchain switched to a JDK that may be incompatible with the execution platform.

fixes #298 