### PR TITLE
Use root test_deps target from bazel_skylib

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -88,7 +88,7 @@ filegroup(
         "//java/common:for_bazel_tests",
         "//java/private:for_bazel_tests",
         "//java/toolchains:for_bazel_tests",
-        "@bazel_skylib//lib:test_deps",
+        "@bazel_skylib//:test_deps",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fixing 
```
$ bazel build //src/test/java/com/google/devtools/build/lib/query2/cquery:FilesOutputFormatterCallbackTest
...
ERROR: /private/var/tmp/_bazel_pcloudy/829441223e9fec5a5a2e3d1dd743fdf0/external/rules_java+/java/BUILD:78:10: in filegroup rule @@rules_java+//java:for_bazel_tests: Visibility error:
target '@@bazel_skylib+//lib:test_deps' is not visible from
target '@@rules_java+//java:for_bazel_tests'
Recommendation: modify the visibility declaration if you think the dependency is legitimate. For more info see https://bazel.build/concepts/visibility
```
after upgrading bazel_skylib which contains https://github.com/bazelbuild/bazel-skylib/pull/508