### PR TITLE
Update the compilation JDK to 25

### DIFF
--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -358,7 +358,7 @@ RELEASES = (8, 9, 10, 11, 17, 21, 25)
 [
     default_java_toolchain(
         name = ("toolchain_java%d" if release <= 11 else "toolchain_jdk_%d") % release,
-        configuration = DEFAULT_TOOLCHAIN_CONFIGURATION if release <= 21 else DEFAULT_TOOLCHAIN_CONFIGURATION | {"java_runtime": ":remotejdk_%d" % release},
+        configuration = DEFAULT_TOOLCHAIN_CONFIGURATION | {"java_runtime": ":remotejdk_25"},
         source_version = "%s" % release,
         target_version = "%s" % release,
     )

--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -98,6 +98,8 @@ _BASE_TOOLCHAIN_CONFIGURATION = dict(
     reduced_classpath_incompatible_processors = [
         "dagger.hilt.processor.internal.root.RootProcessor",  # see b/21307381
     ],
+    # TODO: Update to JDK 25 after some time has passed - it no longer supports
+    # targeting JDK 7.
     java_runtime = Label("//toolchains:remotejdk_21"),
     oneversion = Label("//toolchains:one_version"),
 )


### PR DESCRIPTION
This is necessary to support `--java_runtime_version=remotejdk_25` with lower `--java_language_version` values. JDK 21 already showed warnings when targeting Java 8.