### PR TITLE
Run the bootclasspath through ijar

### DIFF
--- a/test/toolchains/bootclasspath_tests.bzl
+++ b/test/toolchains/bootclasspath_tests.bzl
@@ -14,6 +14,7 @@ def _test_utf_8_environment(name):
 def _test_utf_8_environment_impl(env, target):
     for action in target.actions:
         if action.mnemonic == "Ijar":
+            # ijar isn't sensitive to locales
             continue
         env_subject = env.expect.where(action = action).that_dict(action.env)
         env_subject.keys().contains("LC_CTYPE")

--- a/test/toolchains/bootclasspath_tests.bzl
+++ b/test/toolchains/bootclasspath_tests.bzl
@@ -13,6 +13,8 @@ def _test_utf_8_environment(name):
 
 def _test_utf_8_environment_impl(env, target):
     for action in target.actions:
+        if action.mnemonic == "Ijar":
+            continue
         env_subject = env.expect.where(action = action).that_dict(action.env)
         env_subject.keys().contains("LC_CTYPE")
         env_subject.get("LC_CTYPE", factory = subjects.str).contains("UTF-8")

--- a/toolchains/bootclasspath.bzl
+++ b/toolchains/bootclasspath.bzl
@@ -112,6 +112,7 @@ def _run_ijar(*, actions, label, ijar, input, output):
         executable = ijar,
         arguments = [args],
         progress_message = "Extracting interfaces from %{input}",
+        execution_requirements = _SUPPORTS_PATH_MAPPING,
         mnemonic = "Ijar",
     )
 


### PR DESCRIPTION
This reduces disk space and cache usage and should speed up Turbine actions.

```
ls -lah bazel-out/darwin_arm64-fastbuild/bin/external/rules_java+/toolchains/platformclasspath*.jar 
-r-xr-xr-x@ 1 fmeum    24M Sep 25 11:36 bazel-out/darwin_arm64-fastbuild/bin/external/rules_java+/toolchains/platformclasspath.jar
-r-xr-xr-x@ 1 fmeum   133M Sep 25 11:36 bazel-out/darwin_arm64-fastbuild/bin/external/rules_java+/toolchains/platformclasspath_unstripped.jar
```