### PR TITLE
remove Bazel 6 support

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,15 +14,6 @@ build_targets: &build_targets
   - "-//java/docs/..."
   - "-//test:docs_up_to_date_test"
 
-build_targets_bazel6: &build_targets_bazel6
-  - "//:all"
-  # build java_tools from source
-  - "@remote_java_tools//:ijar_cc_binary"
-  - "@remote_java_tools//:one_version_cc_bin"
-  - "@remote_java_tools//:proguard"
-  - "@remote_java_tools//:singlejar_cc_bin"
-  - "//examples/..."
-
 build_targets_integration: &build_targets_integration
   - "//..."
   - "//:bin_deploy.jar"
@@ -31,10 +22,6 @@ test_targets: &test_targets
   - "//test/..."
   # TODO: re-enable docs after moving them out of https://bazel.build/reference/be/java
   - "-//test:docs_up_to_date_test"
-
-test_targets_bazel6: &test_targets_bazel6
-  - "//test/java/..."
-  - "-//test/java/private/..."
 
 test_target_integration: &test_target_integration
   - "//:MyTest"
@@ -76,26 +63,6 @@ tasks:
     test_targets: *test_targets
     test_flags:
       - "--test_tag_filters=-min_bazel_8,-min_bazel_9"
-# Bazel 6.x
-  build_and_test_bazel6:
-    name: "Bazel 6.5.0"
-    bazel: 6.5.0
-    platform: ${{ all_platforms }}
-    build_targets: *build_targets_bazel6
-    test_targets: *test_targets_bazel6
-    test_flags:
-      - "--test_tag_filters=-min_bazel_7,-min_bazel_8,-min_bazel_9"
-  ubuntu2004_integration_bazel6:
-    name: "Integration w/ Bazel 6.5.0"
-    bazel: 6.5.0
-    platform: ${{ all_platforms }}
-    working_directory: "test/repo"
-    shell_commands:
-    - sh setup.sh
-    batch_commands:
-    - setup.bat
-    build_targets: *build_targets_integration
-    test_targets: *test_target_integration
 
 # Integration tests
   integration_build_and_test:

--- a/toolchains/local_java_repository.bzl
+++ b/toolchains/local_java_repository.bzl
@@ -235,18 +235,10 @@ local_java_runtime(
 )
 """ % (local_java_runtime_name, runtime_name, java_home, version)
 
-    bazel = native.bazel_version
-    if not bazel or bazel >= "7":
-        # Bazel 7+ uses @platforms//host for the host platform.
-        load_host_constraints = 'load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")\n'
-    else:
-        # Bazel 6 uses @local_config_platform instead, but it's being removed in Bazel 9.
-        load_host_constraints = 'load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")\n'
-
     repository_ctx.file(
         "BUILD.bazel",
         'load("@rules_java//toolchains:local_java_repository.bzl", "local_java_runtime")\n' +
-        load_host_constraints +
+        'load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")\n' +
         build_file +
         local_java_runtime_macro,
     )


### PR DESCRIPTION
This version detection was failing on Bazel 10.0.0-pre.20251105.2 because `"1" < "6"`.