### PR TITLE
Attempt to fix missing class error by not using tree artifacts for bootclasspath

### DIFF
--- a/test/check_remote_java_tools_configs.sh
+++ b/test/check_remote_java_tools_configs.sh
@@ -22,7 +22,11 @@ function download_and_check_hash() {
     TMP_FILE=$(mktemp -q /tmp/remotejavatools.XXXXXX)
     echo "fetching $name from $url to ${TMP_FILE}"
     curl --silent -o ${TMP_FILE} -L "$url"
-    actual_hash=`sha256sum ${TMP_FILE} | cut -d' ' -f1`
+    if command -v sha256sum &> /dev/null; then
+        actual_hash=`sha256sum ${TMP_FILE} | cut -d' ' -f1`
+    else
+        actual_hash=`shasum -a 256 ${TMP_FILE} | cut -d' ' -f1`
+    fi
     if [ "${hash}" != "${actual_hash}" ]; then
       echo "ERROR: wrong hash for ${name}! wanted: ${hash}, got: ${actual_hash}"
       exit 1


### PR DESCRIPTION
A few times a year across many thousands of builds we encounter a rare error about the `DumpPlatformClassPath` class being missing. Our Bazel setup uses dynamic execution, builds without the bytes, remote execution + remote caching, and path mapping.

The error we encounter is as follows:
```
Error: Could not find or load main class DumpPlatformClassPath
Caused by: java.lang.ClassNotFoundException: DumpPlatformClassPath
```

I'm guessing that this is happening due to some kind of Bazel bug that happens with our Bazel setup and tree artifacts, i.e., declare_directory.

Best I can tell this is happening because the `DumpPlatformClassPath.class` file is somehow not materializing correctly. I'm not 100% confident about that, but it's my leading hypothesis at this point in time.

This commit changes the actions in `bootclasspath.bzl` to not rely on tree artifacts. Instead, they rely JDK 11+'s ability to launch single-file programs (introduced in JEP 330). This avoids the `javac` action and `declare_directory` previously required to compile `DumpPlatformClassPath`.

Problem is this makes rules_java not compatible with JDK's older than 11.

I'm very open to alternative solutions to this, but I haven't yet come up with a robust, cross platform solution that avoids tree artifacts while also maintaining compatibility with JDKs older than 11.

I wanted to open this PR to get some discussion going.