### PR TITLE
Fix javacopts make variable expansion regression

### DIFF
--- a/java/common/java_semantics.bzl
+++ b/java/common/java_semantics.bzl
@@ -113,4 +113,5 @@ semantics = struct(
     tokenize_javacopts = _tokenize_javacopts,
     PLATFORMS_ROOT = "@platforms//",
     INCOMPATIBLE_DISABLE_NON_EXECUTABLE_JAVA_BINARY = False,  # Flip when java_single_jar is feature complete
+    expand_javacopts_make_variables = True,
 )

--- a/java/common/rules/impl/compile_action.bzl
+++ b/java/common/rules/impl/compile_action.bzl
@@ -135,7 +135,10 @@ def compile_action(
       Files_to_build may include an empty .jar file when there are no sources
       or resources present, whereas runfiles in this case are empty.
     """
-
+    expanded_javacopts = javacopts
+    if semantics.expand_javacopts_make_variables:
+        expanded_javacopts = [ctx.expand_make_variables("javacopts", opt, {}) for opt in expanded_javacopts]
+    expanded_javacopts = [ctx.expand_location(opt) for opt in expanded_javacopts]
     java_info = _compile_private_for_builtins(
         ctx,
         output = output_class_jar,
@@ -151,7 +154,7 @@ def compile_action(
         runtime_deps = runtime_deps,
         exports = exports,
         exported_plugins = exported_plugins,
-        javac_opts = [ctx.expand_location(opt) for opt in javacopts],
+        javac_opts = expanded_javacopts,
         neverlink = neverlink,
         output_source_jar = output_source_jar,
         strict_deps = _filter_strict_deps(strict_deps),

--- a/test/java/bazel/rules/BUILD.bazel
+++ b/test/java/bazel/rules/BUILD.bazel
@@ -1,3 +1,9 @@
 load(":java_binary_tests.bzl", "java_binary_tests")
+load(":java_library_tests.bzl", "java_library_tests")
+load(":java_plugin_tests.bzl", "java_plugin_tests")
 
 java_binary_tests(name = "java_binary_tests")
+
+java_library_tests(name = "java_library_tests")
+
+java_plugin_tests(name = "java_plugin_tests")

--- a/test/java/bazel/rules/java_binary_tests.bzl
+++ b/test/java/bazel/rules/java_binary_tests.bzl
@@ -3,6 +3,8 @@
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load("@rules_testing//lib:util.bzl", "util")
 load("//java:java_binary.bzl", "java_binary")
+load("//test/java/testutil:java_info_subject.bzl", "java_info_subject")
+load("//test/java/testutil:rules/template_var_info_rule.bzl", "template_var_info_rule")
 
 def _test_java_binary_cross_compilation_to_unix(name):
     # A Unix platform that:
@@ -46,10 +48,40 @@ def _test_java_binary_cross_compilation_to_unix_impl(env, target):
     assert_action.substitutions().keys().contains("%jvm_flags%")
     assert_action.inputs().contains_exactly(["java/bazel/rules/java_stub_template.txt"])
 
+def _test_java_binary_javacopts_make_variable_expansion(name):
+    util.helper_target(
+        template_var_info_rule,
+        name = name + "/vars",
+        vars = {
+            "MY_CUSTOM_OPT": "MY_OPT_VALUE",
+        },
+    )
+    util.helper_target(
+        java_binary,
+        name = name + "/bin",
+        srcs = ["java/A.java"],
+        javacopts = ["$(MY_CUSTOM_OPT)"],
+        toolchains = [name + "/vars"],
+    )
+
+    analysis_test(
+        name = name,
+        impl = _test_java_binary_javacopts_make_variable_expansion_impl,
+        target = name + "/bin",
+        # Broken by Starlarkification in the embedded rules in Bazel 7
+        attr_values = {"tags": ["min_bazel_8"]},
+    )
+
+def _test_java_binary_javacopts_make_variable_expansion_impl(env, target):
+    assert_java_info = java_info_subject.from_target(env, target)
+    assert_java_info.compilation_info().javac_options().not_contains("$(MY_CUSTOM_OPT)")
+    assert_java_info.compilation_info().javac_options().contains("MY_OPT_VALUE")
+
 def java_binary_tests(name):
     test_suite(
         name = name,
         tests = [
             _test_java_binary_cross_compilation_to_unix,
+            _test_java_binary_javacopts_make_variable_expansion,
         ],
     )

--- a/test/java/bazel/rules/java_library_tests.bzl
+++ b/test/java/bazel/rules/java_library_tests.bzl
@@ -1,0 +1,44 @@
+"""Tests for the Bazel java_binary rule"""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:util.bzl", "util")
+load("//java:java_library.bzl", "java_library")
+load("//test/java/testutil:java_info_subject.bzl", "java_info_subject")
+load("//test/java/testutil:rules/template_var_info_rule.bzl", "template_var_info_rule")
+
+def _test_java_library_javacopts_make_variable_expansion(name):
+    util.helper_target(
+        template_var_info_rule,
+        name = name + "/vars",
+        vars = {
+            "MY_CUSTOM_OPT": "MY_OPT_VALUE",
+        },
+    )
+    util.helper_target(
+        java_library,
+        name = name + "/lib",
+        srcs = ["java/A.java"],
+        javacopts = ["$(MY_CUSTOM_OPT)"],
+        toolchains = [name + "/vars"],
+    )
+
+    analysis_test(
+        name = name,
+        impl = _test_java_library_javacopts_make_variable_expansion_impl,
+        target = name + "/lib",
+        # Broken by Starlarkification in the embedded rules in Bazel 7
+        attr_values = {"tags": ["min_bazel_8"]},
+    )
+
+def _test_java_library_javacopts_make_variable_expansion_impl(env, target):
+    assert_java_info = java_info_subject.from_target(env, target)
+    assert_java_info.compilation_info().javac_options().not_contains("$(MY_CUSTOM_OPT)")
+    assert_java_info.compilation_info().javac_options().contains("MY_OPT_VALUE")
+
+def java_library_tests(name):
+    test_suite(
+        name = name,
+        tests = [
+            _test_java_library_javacopts_make_variable_expansion,
+        ],
+    )

--- a/test/java/bazel/rules/java_plugin_tests.bzl
+++ b/test/java/bazel/rules/java_plugin_tests.bzl
@@ -1,0 +1,43 @@
+"""Tests for the Bazel java_binary rule"""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:util.bzl", "util")
+load("//java:java_plugin.bzl", "java_plugin")
+load("//test/java/testutil:rules/template_var_info_rule.bzl", "template_var_info_rule")
+
+def _test_java_plugin_javacopts_make_variable_expansion(name):
+    util.helper_target(
+        template_var_info_rule,
+        name = name + "/vars",
+        vars = {
+            "MY_CUSTOM_OPT": "MY_OPT_VALUE",
+        },
+    )
+    util.helper_target(
+        java_plugin,
+        name = name + "/lib",
+        srcs = ["java/A.java"],
+        javacopts = ["$(MY_CUSTOM_OPT)"],
+        toolchains = [name + "/vars"],
+    )
+
+    analysis_test(
+        name = name,
+        impl = _test_java_plugin_javacopts_make_variable_expansion_impl,
+        target = name + "/lib",
+        # Broken by Starlarkification in the embedded rules in Bazel 7
+        attr_values = {"tags": ["min_bazel_8"]},
+    )
+
+def _test_java_plugin_javacopts_make_variable_expansion_impl(env, target):
+    assert_javac = env.expect.that_target(target).action_named("Javac")
+    assert_javac.not_contains_arg("$(MY_CUSTOM_OPT)")
+    assert_javac.contains_at_least_args(["MY_OPT_VALUE"])
+
+def java_plugin_tests(name):
+    test_suite(
+        name = name,
+        tests = [
+            _test_java_plugin_javacopts_make_variable_expansion,
+        ],
+    )

--- a/test/java/testutil/rules/template_var_info_rule.bzl
+++ b/test/java/testutil/rules/template_var_info_rule.bzl
@@ -1,0 +1,13 @@
+"""Test rule to provide TemplateVariableInfo"""
+
+def _template_var_info_rule_impl(ctx):
+    return [
+        platform_common.TemplateVariableInfo(ctx.attr.vars),
+    ]
+
+template_var_info_rule = rule(
+    _template_var_info_rule_impl,
+    attrs = {
+        "vars": attr.string_dict(default = {}),
+    },
+)


### PR DESCRIPTION
Looks like this was a regression introduced when we Starlarkified the rules. Unfortunately, we apparently had no test coverage for this, and no usages internally either. No one has complained about it since either - until now.

Fixes https://github.com/bazelbuild/rules_java/issues/345