### PR TITLE
Add coverage include and exclude flags

### DIFF
--- a/java/common/rules/basic_java_library.bzl
+++ b/java/common/rules/basic_java_library.bzl
@@ -16,6 +16,7 @@
 Common code for reuse across java_* rules
 """
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//java/common:java_semantics.bzl", "semantics")
 load("//java/private:java_common.bzl", "java_common")
 load("//java/private:java_info.bzl", "JavaPluginInfo")
@@ -35,5 +36,7 @@ BASIC_JAVA_LIBRARY_IMPLICIT_ATTRS = merge_attrs(
             providers = [java_common.JavaToolchainInfo],
         ),
         "_use_auto_exec_groups": attr.bool(default = True),
+        "_coverage_includes": attr.label(default = "//java/config:coverage_includes", providers = [BuildSettingInfo]),
+        "_coverage_excludes": attr.label(default = "//java/config:coverage_excludes", providers = [BuildSettingInfo]),
     },
 )

--- a/java/common/rules/impl/basic_java_library_impl.bzl
+++ b/java/common/rules/impl/basic_java_library_impl.bzl
@@ -16,6 +16,7 @@
 Common code for reuse across java_* rules
 """
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//java/common/rules:android_lint.bzl", "android_lint_subrule")
 load("//java/private:boot_class_path_info.bzl", "BootClassPathInfo")
@@ -151,6 +152,8 @@ def basic_java_library(
         add_opens = add_opens,
         bootclasspath = bootclasspath[BootClassPathInfo] if bootclasspath else None,
         javabuilder_jvm_flags = javabuilder_jvm_flags,
+        coverage_includes = ctx.attr._coverage_includes[BuildSettingInfo].value,
+        coverage_excludes = ctx.attr._coverage_excludes[BuildSettingInfo].value,
     )
     target = {"JavaInfo": java_info}
 

--- a/java/common/rules/impl/compile_action.bzl
+++ b/java/common/rules/impl/compile_action.bzl
@@ -60,7 +60,9 @@ def compile_action(
         add_exports = [],
         add_opens = [],
         bootclasspath = None,
-        javabuilder_jvm_flags = None):
+        javabuilder_jvm_flags = None,
+        coverage_includes = [],
+        coverage_excludes = []):
     """
     Creates actions that compile Java sources, produce source jar, and produce header jar and returns JavaInfo.
 
@@ -123,6 +125,8 @@ def compile_action(
       add_opens: (list[str]) Allow this library to reflectively access the given <module>/<package>.
       bootclasspath: (BootClassPathInfo) The set of JDK APIs to compile this library against.
       javabuilder_jvm_flags: (list[str]) Additional JVM flags to pass to JavaBuilder.
+      coverage_includes: (list[str]) A list of patterns to include in code coverage.
+      coverage_excludes: (list[str]) A list of patterns to exclude from code coverage.
 
     Returns:
       ((JavaInfo, {files_to_build: list[File],
@@ -163,6 +167,8 @@ def compile_action(
         add_opens = add_opens,
         bootclasspath = bootclasspath,
         javabuilder_jvm_flags = javabuilder_jvm_flags,
+        coverage_includes = coverage_includes,
+        coverage_excludes = coverage_excludes,
     )
 
     compilation_info = struct(

--- a/java/config/BUILD.bazel
+++ b/java/config/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@bazel_skylib//rules:common_settings.bzl", "repeatable_string_flag")
+
+repeatable_string_flag(
+    name = "coverage_includes",
+    build_setting_default = [],
+    visibility = ["//visibility:public"],
+)
+
+repeatable_string_flag(
+    name = "coverage_excludes",
+    build_setting_default = [],
+    visibility = ["//visibility:public"],
+)

--- a/java/private/java_common_internal.bzl
+++ b/java/private/java_common_internal.bzl
@@ -68,7 +68,9 @@ def compile(
         include_compilation_info = True,
         classpath_resources = [],
         resource_jars = [],
-        injecting_rule_kind = None):
+        injecting_rule_kind = None,
+        coverage_includes = [],
+        coverage_excludes = []):
     """Compiles Java source files/jars from the implementation of a Starlark rule
 
     The result is a provider that represents the results of the compilation and can be added to the
@@ -118,6 +120,8 @@ def compile(
         add_exports: ([str]) Allow this library to access the given <module>/<package>. Optional.
         add_opens: ([str]) Allow this library to reflectively access the given <module>/<package>.
              Optional.
+        coverage_includes: (list[str]) A list of patterns to include in code coverage. Optional.
+        coverage_excludes: (list[str]) A list of patterns to exclude from code coverage. Optional.
 
     Returns:
         (JavaInfo)
@@ -305,6 +309,8 @@ def compile(
         enable_direct_classpath,
         annotation_processor_additional_inputs,
         annotation_processor_additional_outputs,
+        coverage_includes,
+        coverage_excludes,
     )
 
     create_output_source_jar = len(source_files) > 0 or source_jars != [output_source_jar]


### PR DESCRIPTION
This is my first time writing custom starlark rules. Please let me know if I need to change anything/did anything wrong.

These new flags allow filtering which classes get instrumented when collecting coverage. The include and exclude lists are the same mechanism as used by [JaCoCo](https://www.jacoco.org/jacoco/trunk/doc/agent.html).

Example for only instrumenting classes in the `com.example` package:
```bash
bazel coverage //... --@rules_java//java/config:coverage_includes=com/example/*
```

I'm not sure if we should add tests for these new flags or if that's even possible. These new flags also need to be documented somewhere, but I wasn't sure where to put documentation for them.

Requires https://github.com/bazelbuild/bazel/pull/29502 to be merged.