### PR TITLE
Propagate `.jdeps` for `java_import`

### DIFF
--- a/java/common/rules/impl/bazel_java_import_impl.bzl
+++ b/java/common/rules/impl/bazel_java_import_impl.bzl
@@ -117,14 +117,21 @@ def bazel_java_import_rule(
 
     jdeps_artifact = None
     merged_java_info = java_common.merge(all_deps)
+
+    # import_deps_check is always run to generate the jdeps proto for downstream compile actions,
+    # but may be silenced.
     if not skip_incomplete_deps_check and "incomplete-deps" not in ctx.attr.tags:
-        jdeps_artifact = import_deps_check(
-            ctx,
-            collected_jars,
-            merged_java_info.compile_jars,
-            merged_java_info.transitive_compile_time_jars,
-            "java_import",
-        )
+        checking_mode = "error"
+    else:
+        checking_mode = "silence"
+    jdeps_artifact = import_deps_check(
+        ctx,
+        collected_jars,
+        merged_java_info.compile_jars,
+        merged_java_info.transitive_compile_time_jars,
+        "java_import",
+        checking_mode = checking_mode,
+    )
 
     compilation_to_runtime_jar_map = _process_with_ijars_if_needed(collected_jars, ctx)
     runtime_deps_list = [runtime_dep[JavaInfo] for runtime_dep in runtime_deps if JavaInfo in runtime_dep]
@@ -134,6 +141,7 @@ def bazel_java_import_rule(
         java_infos.append(JavaInfo(
             output_jar = jar,
             compile_jar = compilation_to_runtime_jar_map[jar],
+            compile_jdeps = jdeps_artifact,
             deps = all_deps,
             runtime_deps = runtime_deps_list,
             neverlink = neverlink,

--- a/java/common/rules/impl/bazel_java_import_impl.bzl
+++ b/java/common/rules/impl/bazel_java_import_impl.bzl
@@ -115,7 +115,6 @@ def bazel_java_import_rule(
     collected_jars = _collect_jars(ctx, jars)
     all_deps = _filter_provider(JavaInfo, deps, exports)
 
-    jdeps_artifact = None
     merged_java_info = java_common.merge(all_deps)
 
     # import_deps_check is always run to generate the jdeps proto for downstream compile actions,

--- a/java/common/rules/impl/import_deps_check.bzl
+++ b/java/common/rules/impl/import_deps_check.bzl
@@ -23,7 +23,8 @@ def import_deps_check(
         jars_to_check,
         declared_deps,
         transitive_deps,
-        rule_class):
+        rule_class,
+        checking_mode = "error"):
     """
     Creates actions that checks import deps for java rules.
 
@@ -33,6 +34,7 @@ def import_deps_check(
       declared_deps: (list[File]) A list of direct dependencies.
       transitive_deps: (list[File]) A list of transitive dependencies.
       rule_class: (String) Rule class.
+      checking_mode: (String) One of "error", "warning" or "silence".
 
     Returns:
       (File) Output file of the created action.
@@ -53,9 +55,11 @@ def import_deps_check(
         before_each = "--classpath_entry",
     )
     args.add_all(java_toolchain.bootclasspath, before_each = "--bootclasspath_entry")
-    args.add("--checking_mode=error")
+    args.add(checking_mode, format = "--checking_mode=%s")
     args.add("--jdeps_output", jdeps_output)
-    args.add("--rule_label", ctx.label)
+
+    # ctx.label can start with an @ and must not be understood as a flagfile.
+    args.add(ctx.label, format = "--rule_label=%s")
 
     semantics.update_args_for_import_deps(ctx, args)
     inputs = depset(

--- a/test/java/bazel/rules/BUILD.bazel
+++ b/test/java/bazel/rules/BUILD.bazel
@@ -1,9 +1,12 @@
 load(":java_binary_tests.bzl", "java_binary_tests")
+load(":java_import_tests.bzl", "java_import_tests")
 load(":java_library_tests.bzl", "java_library_tests")
 load(":java_plugin_tests.bzl", "java_plugin_tests")
 load(":java_test_tests.bzl", "java_test_tests")
 
 java_binary_tests(name = "java_binary_tests")
+
+java_import_tests(name = "java_import_tests")
 
 java_library_tests(name = "java_library_tests")
 

--- a/test/java/bazel/rules/java_import_tests.bzl
+++ b/test/java/bazel/rules/java_import_tests.bzl
@@ -1,0 +1,42 @@
+"""Tests for the Bazel java_import rule"""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:util.bzl", "util")
+load("//java:java_import.bzl", "java_import")
+
+def _test_import_deps_checker_checking_mode(name):
+    util.helper_target(
+        java_import,
+        name = name + "/import-jar",
+        jars = ["import.jar"],
+        deps = [name + "/depjar"],
+    )
+    util.helper_target(
+        java_import,
+        name = name + "/depjar",
+        jars = ["depjar.jar"],
+    )
+
+    analysis_test(
+        name = name,
+        impl = _test_import_deps_checker_checking_mode_impl,
+        target = name + "/import-jar",
+        # The rules_java Starlark implementation is used from Bazel 8 on.
+        attr_values = {"tags": ["min_bazel_8"]},
+    )
+
+def _test_import_deps_checker_checking_mode_impl(env, target):
+    # java_import only generates the jdeps proto, it never fails the build on incomplete deps.
+    assert_action = env.expect.that_target(target).action_named("ImportDepsChecker")
+    assert_action.contains_flag_values([
+        ("--checking_mode", "silence"),
+        ("--rule_label", "//{package}:{name}"),
+    ])
+
+def java_import_tests(name):
+    test_suite(
+        name = name,
+        tests = [
+            _test_import_deps_checker_checking_mode,
+        ],
+    )

--- a/test/java/common/rules/java_import_tests.bzl
+++ b/test/java/common/rules/java_import_tests.bzl
@@ -178,6 +178,59 @@ def _test_deps_impl(env, targets):
         "{package}/depjar.jar",
     ])
 
+# Regression test for https://github.com/bazelbuild/rules_java/issues/362: an import with deps
+# records a jdeps proto as its compile_jdeps so that reduced classpaths of downstream compilations
+# are not missing its transitive dependencies.
+def _test_compile_jdeps_propagated_for_deps(name):
+    util.helper_target(
+        java_import,
+        name = name + "/import-jar",
+        jars = ["import.jar"],
+        deps = [name + "/depjar"],
+    )
+    util.helper_target(
+        java_import,
+        name = name + "/incomplete-jar",
+        jars = ["incomplete.jar"],
+        deps = [name + "/depjar"],
+        tags = ["incomplete-deps"],
+    )
+    util.helper_target(
+        java_import,
+        name = name + "/depjar",
+        jars = ["depjar.jar"],
+    )
+
+    analysis_test(
+        name = name,
+        impl = _test_compile_jdeps_propagated_for_deps_impl,
+        targets = {
+            "with_deps": name + "/import-jar",
+            "without_deps": name + "/depjar",
+        },
+        # Requires the rules_java Starlark implementation to be used.
+        attr_values = {"tags": ["min_bazel_9"]},
+    )
+
+def _test_compile_jdeps_propagated_for_deps_impl(env, targets):
+    with_deps = [
+        f.basename
+        for f in targets.with_deps[JavaInfo]._compile_time_java_dependencies.to_list()
+    ]
+    env.expect.that_collection(with_deps).contains_exactly(["jdeps.proto"])
+
+    incomplete_deps = [
+        f.basename
+        for f in targets.without_deps[JavaInfo]._compile_time_java_dependencies.to_list()
+    ]
+    env.expect.that_collection(incomplete_deps).contains_exactly(["jdeps.proto"])
+
+    without_deps = [
+        f.basename
+        for f in targets.without_deps[JavaInfo]._compile_time_java_dependencies.to_list()
+    ]
+    env.expect.that_collection(without_deps).contains_exactly(["jdeps.proto"])
+
 # Regression test for b/262751943.
 def _test_commandline_contains_target_label(name):
     util.helper_target(
@@ -959,6 +1012,7 @@ def java_import_tests(name):
             _test_simple,
             _test_with_java_library,
             _test_deps,
+            _test_compile_jdeps_propagated_for_deps,
             _test_commandline_contains_target_label,
             _test_java_library_allows_import_in_deps,
             _test_module_flags,

--- a/test/java/common/rules/java_import_tests.bzl
+++ b/test/java/common/rules/java_import_tests.bzl
@@ -178,7 +178,7 @@ def _test_deps_impl(env, targets):
         "{package}/depjar.jar",
     ])
 
-# Regression test for https://github.com/bazelbuild/rules_java/issues/362: an import with deps
+# Regression test for https://github.com/bazelbuild/rules_java/issues/362: every java_import
 # records a jdeps proto as its compile_jdeps so that reduced classpaths of downstream compilations
 # are not missing its transitive dependencies.
 def _test_compile_jdeps_propagated_for_deps(name):
@@ -205,31 +205,49 @@ def _test_compile_jdeps_propagated_for_deps(name):
         name = name,
         impl = _test_compile_jdeps_propagated_for_deps_impl,
         targets = {
+            "incomplete_deps": name + "/incomplete-jar",
             "with_deps": name + "/import-jar",
             "without_deps": name + "/depjar",
         },
-        # Requires the rules_java Starlark implementation to be used.
-        attr_values = {"tags": ["min_bazel_9"]},
+        # The rules_java Starlark implementation is used from Bazel 8 on.
+        attr_values = {"tags": ["min_bazel_8"]},
     )
 
 def _test_compile_jdeps_propagated_for_deps_impl(env, targets):
-    with_deps = [
-        f.basename
-        for f in targets.with_deps[JavaInfo]._compile_time_java_dependencies.to_list()
-    ]
-    env.expect.that_collection(with_deps).contains_exactly(["jdeps.proto"])
+    for target in [targets.with_deps, targets.incomplete_deps, targets.without_deps]:
+        assert_compilation_args = java_info_subject.from_target(env, target).compilation_args()
+        assert_compilation_args.compile_time_java_dependencies().contains_exactly([
+            "{package}/_java_import/{name}/jdeps.proto",
+        ])
 
-    incomplete_deps = [
-        f.basename
-        for f in targets.without_deps[JavaInfo]._compile_time_java_dependencies.to_list()
-    ]
-    env.expect.that_collection(incomplete_deps).contains_exactly(["jdeps.proto"])
+def _test_import_deps_checker_checking_mode(name):
+    util.helper_target(
+        java_import,
+        name = name + "/import-jar",
+        jars = ["import.jar"],
+        deps = [name + "/depjar"],
+    )
+    util.helper_target(
+        java_import,
+        name = name + "/depjar",
+        jars = ["depjar.jar"],
+    )
 
-    without_deps = [
-        f.basename
-        for f in targets.without_deps[JavaInfo]._compile_time_java_dependencies.to_list()
-    ]
-    env.expect.that_collection(without_deps).contains_exactly(["jdeps.proto"])
+    analysis_test(
+        name = name,
+        impl = _test_import_deps_checker_checking_mode_impl,
+        target = name + "/import-jar",
+        # The rules_java Starlark implementation is used from Bazel 8 on.
+        attr_values = {"tags": ["min_bazel_8"]},
+    )
+
+def _test_import_deps_checker_checking_mode_impl(env, target):
+    # java_import only generates the jdeps proto, it never fails the build on incomplete deps.
+    assert_action = env.expect.that_target(target).action_named("ImportDepsChecker")
+    assert_action.contains_flag_values([
+        ("--checking_mode", "silence"),
+        ("--rule_label", "//{package}:{name}"),
+    ])
 
 # Regression test for b/262751943.
 def _test_commandline_contains_target_label(name):
@@ -1013,6 +1031,7 @@ def java_import_tests(name):
             _test_with_java_library,
             _test_deps,
             _test_compile_jdeps_propagated_for_deps,
+            _test_import_deps_checker_checking_mode,
             _test_commandline_contains_target_label,
             _test_java_library_allows_import_in_deps,
             _test_module_flags,

--- a/test/java/common/rules/java_import_tests.bzl
+++ b/test/java/common/rules/java_import_tests.bzl
@@ -220,35 +220,6 @@ def _test_compile_jdeps_propagated_for_deps_impl(env, targets):
             "{package}/_java_import/{name}/jdeps.proto",
         ])
 
-def _test_import_deps_checker_checking_mode(name):
-    util.helper_target(
-        java_import,
-        name = name + "/import-jar",
-        jars = ["import.jar"],
-        deps = [name + "/depjar"],
-    )
-    util.helper_target(
-        java_import,
-        name = name + "/depjar",
-        jars = ["depjar.jar"],
-    )
-
-    analysis_test(
-        name = name,
-        impl = _test_import_deps_checker_checking_mode_impl,
-        target = name + "/import-jar",
-        # The rules_java Starlark implementation is used from Bazel 8 on.
-        attr_values = {"tags": ["min_bazel_8"]},
-    )
-
-def _test_import_deps_checker_checking_mode_impl(env, target):
-    # java_import only generates the jdeps proto, it never fails the build on incomplete deps.
-    assert_action = env.expect.that_target(target).action_named("ImportDepsChecker")
-    assert_action.contains_flag_values([
-        ("--checking_mode", "silence"),
-        ("--rule_label", "//{package}:{name}"),
-    ])
-
 # Regression test for b/262751943.
 def _test_commandline_contains_target_label(name):
     util.helper_target(
@@ -1031,7 +1002,6 @@ def java_import_tests(name):
             _test_with_java_library,
             _test_deps,
             _test_compile_jdeps_propagated_for_deps,
-            _test_import_deps_checker_checking_mode,
             _test_commandline_contains_target_label,
             _test_java_library_allows_import_in_deps,
             _test_module_flags,

--- a/toolchains/default_java_toolchain.bzl
+++ b/toolchains/default_java_toolchain.bzl
@@ -76,6 +76,7 @@ _DEFAULT_JAVA_LANGUAGE_VERSION = "11"
 
 # Default java_toolchain parameters
 _BASE_TOOLCHAIN_CONFIGURATION = dict(
+    deps_checker = Label("@remote_java_tools//:ImportDepsChecker"),
     forcibly_disable_header_compilation = False,
     genclass = Label("@remote_java_tools//:GenClass"),
     header_compiler = Label("@remote_java_tools//:TurbineDirect"),


### PR DESCRIPTION
Downstream Java compilation actions need accurate `.jdeps` files for their reduced classpath optimization. With this change, `java_import` now always runs `ImportDepsChecker` to generate this file, but possibly suppresses its outputs. Note that Bazel (but not Blaze) always silences the output.

Fixes #362