### PR TITLE
Mark remote JDK toolchain config repositories reproducible

### DIFF
--- a/toolchains/remote_java_repository.bzl
+++ b/toolchains/remote_java_repository.bzl
@@ -24,6 +24,10 @@ def _toolchain_config_impl(ctx):
     ctx.file("WORKSPACE", "workspace(name = \"{name}\")\n".format(name = ctx.name))
     ctx.file("BUILD.bazel", ctx.attr.build_file)
 
+    # rules_java supports Bazel versions without repository_ctx.repo_metadata.
+    if hasattr(ctx, "repo_metadata"):
+        return ctx.repo_metadata(reproducible = True)
+
 _toolchain_config = repository_rule(
     local = True,
     implementation = _toolchain_config_impl,


### PR DESCRIPTION
The `_toolchain_config` repository rule creates the remote JDK `*_toolchain_config_repo` repositories from deterministic `WORKSPACE` and `BUILD.bazel` content. Return `repo_metadata(reproducible = True)` so Bazel can use the repository contents cache for these repositories, with a `hasattr` guard for Bazel versions that do not provide `repository_ctx.repo_metadata`.

Validation:

- Bazel 9.1.1 query of all 200 targets in the 40 remote JDK toolchain config repositories
- Bazel 7.6.1 query of `@remotejdk21_macos_aarch64_toolchain_config_repo//:all`
- `buildifier -mode=check toolchains/remote_java_repository.bzl`
