### PR TITLE
Support RunfilesGroupInfo

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "bazel_features", version = "1.30.0")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "rules_runfiles_group", version = "0.1.0")
 bazel_dep(name = "protobuf", version = "32.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 

--- a/distro/relnotes.bzl
+++ b/distro/relnotes.bzl
@@ -20,11 +20,12 @@ bazel_dep(name = "rules_java", version = "{VERSION}")
 
 **WORKSPACE setup**
 
-With Bazel 8.0.0 and before 8.3.0, add the following to your `.bazelrc` file:
+With Bazel 8.x, add the following to your `.bazelrc` file:
 
 ~~~
+# https://github.com/bazelbuild/bazel/issues/23043
 # https://github.com/bazelbuild/bazel/pull/26119
-common --repositories_without_autoloads=bazel_features_version,bazel_features_globals
+common --repositories_without_autoloads=rules_runfiles_group,bazel_features_version,bazel_features_globals
 ~~~
 
 In all cases, add the following to your `WORKSPACE` file:

--- a/java/bazel/rules/BUILD.bazel
+++ b/java/bazel/rules/BUILD.bazel
@@ -36,6 +36,8 @@ bzl_library(
         "@bazel_skylib//lib:paths",
         "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_cc//cc/common",
+        "@rules_runfiles_group//runfiles_group:lib",
+        "@rules_runfiles_group//runfiles_group:providers",
     ],
 )
 

--- a/java/bazel/rules/bazel_java_binary.bzl
+++ b/java/bazel/rules/bazel_java_binary.bzl
@@ -16,6 +16,8 @@
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
+load("@rules_runfiles_group//runfiles_group:lib.bzl", "runfiles_groups")
+load("@rules_runfiles_group//runfiles_group:providers.bzl", "RunfilesGroupInfo")
 load("//java/common:java_semantics.bzl", "semantics")
 load(
     "//java/common/rules:android_lint.bzl",
@@ -26,6 +28,16 @@ load("//java/common/rules:rule_util.bzl", "merge_attrs")
 load("//java/common/rules/impl:java_binary_deploy_jar.bzl", "create_deploy_archives")
 load("//java/common/rules/impl:java_binary_impl.bzl", "basic_java_binary", "binary_provider_helper")
 load("//java/common/rules/impl:java_helper.bzl", "helper")
+load(
+    "//java/common/rules/impl:runfiles_group_support.bzl",
+    "BINARY_GROUP",
+    "JAVA_RUNTIME_GROUP",
+    "MERGE_AFFINITY",
+    "RUNFILES_GROUP_ATTRS",
+    "collect_entries",
+    "own_kind",
+    "runfiles_groups_enabled",
+)
 load("//java/private:java_info.bzl", "JavaInfo")
 
 def _bazel_java_binary_impl(ctx):
@@ -100,9 +112,11 @@ def bazel_base_binary_impl(ctx, is_test_rule_class):
 
     runfiles = default_info.runfiles
 
+    toolchain_files = depset()
     if executable:
         runtime_toolchain = semantics.find_java_runtime_toolchain(ctx)
-        runfiles = runfiles.merge(ctx.runfiles(transitive_files = runtime_toolchain.files))
+        toolchain_files = runtime_toolchain.files
+        runfiles = runfiles.merge(ctx.runfiles(transitive_files = toolchain_files))
 
     test_support = helper.get_test_support(ctx)
     if test_support:
@@ -113,6 +127,8 @@ def bazel_base_binary_impl(ctx, is_test_rule_class):
         runfiles = runfiles,
         executable = default_info.executable,
     )
+
+    _add_runfiles_group_provider(providers, ctx, java_attrs, executable, toolchain_files, test_support)
 
     info = providers.pop("InternalDeployJarInfo")
     create_deploy_archives(
@@ -127,6 +143,52 @@ def bazel_base_binary_impl(ctx, is_test_rule_class):
     )
 
     return providers.values()
+
+def _add_runfiles_group_provider(providers, ctx, java_attrs, executable, toolchain_files, test_support):
+    if not runfiles_groups_enabled(ctx):
+        return
+
+    own = [runfiles_groups.entry(
+        name = ctx.label,
+        content = java_attrs.runtime_jars,
+        kind = own_kind(ctx.label),
+        rank = runfiles_groups.RANK_EXECUTABLE,
+        merge_affinity = MERGE_AFFINITY,
+    )]
+
+    executable_group = None
+    if executable:
+        # toolchain_files is only populated for a target with an executable.
+        own.append(runfiles_groups.entry(
+            name = JAVA_RUNTIME_GROUP,
+            content = toolchain_files,
+            kind = "foundation",
+            rank = runfiles_groups.RANK_FOUNDATION,
+            do_not_merge = True,
+            merge_affinity = MERGE_AFFINITY,
+        ))
+        own.append(runfiles_groups.entry(
+            name = BINARY_GROUP,
+            content = depset([executable]),
+            kind = own_kind(ctx.label),
+            rank = runfiles_groups.RANK_EXECUTABLE,
+            merge_affinity = MERGE_AFFINITY,
+        ))
+        executable_group = BINARY_GROUP
+
+    deps = [ctx.attr.deps, ctx.attr.runtime_deps]
+    if test_support:
+        deps.append(test_support)
+
+    providers["RunfilesGroupInfo"] = RunfilesGroupInfo(
+        entries = collect_entries(
+            ctx,
+            deps = deps,
+            data = [getattr(ctx.attr, "data", [])],
+            own = own,
+        ),
+        executable_group = executable_group,
+    )
 
 def _get_coverage_runner(ctx):
     if ctx.configuration.coverage_enabled and ctx.attr.create_executable:
@@ -370,6 +432,7 @@ logic as the Java package of source files. For example, a source file at
             executable = True,
         ),
     } if not bazel_features.rules._has_launcher_maker_toolchain else {},
+    RUNFILES_GROUP_ATTRS,
 )
 
 def make_java_binary(executable):

--- a/java/bazel/rules/bazel_java_import.bzl
+++ b/java/bazel/rules/bazel_java_import.bzl
@@ -18,7 +18,9 @@ Definition of java_import rule.
 
 load("//java/common:java_semantics.bzl", "semantics")
 load("//java/common/rules:java_import.bzl", "JAVA_IMPORT_ATTRS")
+load("//java/common/rules:rule_util.bzl", "merge_attrs")
 load("//java/common/rules/impl:bazel_java_import_impl.bzl", "bazel_java_import_rule")
+load("//java/common/rules/impl:runfiles_group_support.bzl", "RUNFILES_GROUP_ATTRS")
 load("//java/private:java_info.bzl", "JavaInfo")
 
 def _proxy(ctx):
@@ -33,6 +35,7 @@ def _proxy(ctx):
         ctx.files.proguard_specs,
         ctx.attr.add_exports,
         ctx.attr.add_opens,
+        runfiles_weight = ctx.attr.runfiles_weight,
     ).values()
 
 java_import = rule(
@@ -59,7 +62,7 @@ java_import = rule(
 </code>
 </pre>
     """,
-    attrs = JAVA_IMPORT_ATTRS,
+    attrs = merge_attrs(JAVA_IMPORT_ATTRS, RUNFILES_GROUP_ATTRS),
     provides = [JavaInfo],
     fragments = ["java", "cpp"],
     toolchains = [semantics.JAVA_TOOLCHAIN],

--- a/java/bazel/rules/bazel_java_library.bzl
+++ b/java/bazel/rules/bazel_java_library.bzl
@@ -19,7 +19,9 @@ Definition of java_library rule.
 load("//java/common:java_semantics.bzl", "semantics")
 load("//java/common/rules:android_lint.bzl", "android_lint_subrule")
 load("//java/common/rules:java_library.bzl", "JAVA_LIBRARY_ATTRS")
+load("//java/common/rules:rule_util.bzl", "merge_attrs")
 load("//java/common/rules/impl:bazel_java_library_impl.bzl", "bazel_java_library_rule")
+load("//java/common/rules/impl:runfiles_group_support.bzl", "RUNFILES_GROUP_ATTRS")
 load("//java/private:java_info.bzl", "JavaInfo")
 
 def _proxy(ctx):
@@ -53,7 +55,7 @@ java_library = rule(
     jar").</li>
 </ul>
     """,
-    attrs = JAVA_LIBRARY_ATTRS,
+    attrs = merge_attrs(JAVA_LIBRARY_ATTRS, RUNFILES_GROUP_ATTRS),
     provides = [JavaInfo],
     outputs = {
         "classjar": "lib%{name}.jar",

--- a/java/common/rules/impl/BUILD
+++ b/java/common/rules/impl/BUILD
@@ -23,6 +23,8 @@ bzl_library(
         "//java/common:proguard_spec_info_bzl",
         "@com_google_protobuf//bazel/common:proto_info_bzl",
         "@rules_cc//cc/common:cc_helper_bzl",
+        "@rules_runfiles_group//runfiles_group:lib",
+        "@rules_runfiles_group//runfiles_group:providers",
     ],
 )
 

--- a/java/common/rules/impl/bazel_java_import_impl.bzl
+++ b/java/common/rules/impl/bazel_java_import_impl.bzl
@@ -17,9 +17,12 @@ Definition of java_import rule.
 """
 
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_runfiles_group//runfiles_group:lib.bzl", "runfiles_groups")
+load("@rules_runfiles_group//runfiles_group:providers.bzl", "RunfilesGroupInfo")
 load("//java/common:java_semantics.bzl", "semantics")
 load("//java/common/rules/impl:basic_java_library_impl.bzl", "construct_defaultinfo")
 load("//java/common/rules/impl:import_deps_check.bzl", "import_deps_check")
+load("//java/common/rules/impl:runfiles_group_support.bzl", "MERGE_AFFINITY", "collect_entries", "runfiles_groups_enabled")
 load("//java/private:java_common.bzl", "java_common")
 load("//java/private:java_common_internal.bzl", _run_ijar_private_for_builtins = "run_ijar")
 load("//java/private:java_info.bzl", "JavaInfo")
@@ -85,7 +88,8 @@ def bazel_java_import_rule(
         add_exports = [],
         add_opens = [],
         permit_exports = True,
-        skip_incomplete_deps_check = True):
+        skip_incomplete_deps_check = True,
+        runfiles_weight = 0):
     """Implements java_import.
 
     This rule allows the use of precompiled .jar files as libraries in other Java rules.
@@ -103,6 +107,7 @@ def bazel_java_import_rule(
       add_opens: (list[str]) Allow this library to reflectively access the given <module>/<package>.
       permit_exports: (bool) Allow using exports
       skip_incomplete_deps_check: (bool) If this target is allowed to have incomplete deps
+      runfiles_weight: (int) Weight hint for the target's runfiles group entry. If > 0, set as weight.
 
     Returns:
       (list[provider]) A list containing DefaultInfo, JavaInfo,
@@ -182,4 +187,26 @@ def bazel_java_import_rule(
             "_hidden_top_level_INTERNAL_": target["ProguardSpecProvider"].specs,
         }
     )
+
+    if not neverlink:
+        _add_runfiles_group_provider(target, ctx, collected_jars, deps, exports, runtime_deps, runfiles_weight = runfiles_weight)
+
     return target
+
+def _add_runfiles_group_provider(target, ctx, own_jars, deps, exports, runtime_deps, runfiles_weight = 0):
+    if not runfiles_groups_enabled(ctx):
+        return
+
+    target["RunfilesGroupInfo"] = RunfilesGroupInfo(entries = collect_entries(
+        ctx,
+        deps = [deps, exports, runtime_deps],
+        data = [getattr(ctx.attr, "data", [])],
+        own = [runfiles_groups.entry(
+            name = ctx.label,
+            content = depset(own_jars),
+            kind = "third_party",
+            rank = runfiles_groups.RANK_SHARED_DEPS,
+            weight = runfiles_weight if runfiles_weight > 0 else None,
+            merge_affinity = MERGE_AFFINITY,
+        )],
+    ))

--- a/java/common/rules/impl/bazel_java_library_impl.bzl
+++ b/java/common/rules/impl/bazel_java_library_impl.bzl
@@ -16,7 +16,10 @@
 Definition of java_library rule.
 """
 
+load("@rules_runfiles_group//runfiles_group:lib.bzl", "runfiles_groups")
+load("@rules_runfiles_group//runfiles_group:providers.bzl", "RunfilesGroupInfo")
 load("//java/common/rules/impl:basic_java_library_impl.bzl", "basic_java_library", "construct_defaultinfo")
+load("//java/common/rules/impl:runfiles_group_support.bzl", "MERGE_AFFINITY", "collect_entries", "own_kind", "runfiles_groups_enabled")
 
 # copybara: default visibility
 
@@ -98,4 +101,23 @@ def bazel_java_library_rule(
     )
     target["OutputGroupInfo"] = OutputGroupInfo(**base_info.output_groups)
 
+    if not neverlink:
+        _add_runfiles_group_provider(target, ctx, base_info.runfiles, deps, exports, runtime_deps)
+
     return target
+
+def _add_runfiles_group_provider(target, ctx, own_runfiles, deps, exports, runtime_deps):
+    if not runfiles_groups_enabled(ctx):
+        return
+
+    target["RunfilesGroupInfo"] = RunfilesGroupInfo(entries = collect_entries(
+        ctx,
+        deps = [deps, exports, runtime_deps],
+        data = [getattr(ctx.attr, "data", [])],
+        own = [runfiles_groups.entry(
+            name = ctx.label,
+            content = depset(own_runfiles),
+            kind = own_kind(ctx.label),
+            merge_affinity = MERGE_AFFINITY,
+        )],
+    ))

--- a/java/common/rules/impl/runfiles_group_support.bzl
+++ b/java/common/rules/impl/runfiles_group_support.bzl
@@ -1,0 +1,152 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Shared pieces for emitting RunfilesGroupInfo from the Java rules.
+"""
+
+load("@rules_runfiles_group//runfiles_group:lib.bzl", "runfiles_groups")
+load("@rules_runfiles_group//runfiles_group:providers.bzl", "RunfilesGroupInfo")
+load("//java/private:java_info.bzl", "JavaInfo")
+
+# copybara: default visibility
+
+# Stamped on every group the Java rules produce, so that JVM-shaped groups stay
+# together when a packager has to merge groups to fit a layer limit.
+MERGE_AFFINITY = "rules_java"
+
+# Named groups the java_binary / java_test rules contribute. Both are shared by
+# every binary, so they are named with strings rather than with a Label.
+JAVA_RUNTIME_GROUP = "rules_java#java_runtime"
+BINARY_GROUP = "rules_java#binary"
+
+# Merged into the attrs of every rule that emits RunfilesGroupInfo, giving it
+# access to the global on/off switch read by runfiles_groups_enabled().
+RUNFILES_GROUP_ATTRS = runfiles_groups.RULE_ATTRS
+
+def own_kind(label):
+    """Returns the `kind` of the group holding a target's own outputs.
+
+    Only a target in the main repository is first-party. Plenty of Java targets
+    Bazel builds from source belong to somebody else -- the protobuf runtime,
+    say -- and a packaging rule that selects on `kind` should not have to treat
+    those as the user's own code.
+
+    Args:
+      label: (Label) The label of the target owning the group.
+
+    Returns:
+      (str) One of runfiles_groups.KINDS.
+    """
+    return "first_party" if label.repo_name == "" else "third_party"
+
+def runfiles_groups_enabled(ctx):
+    """Returns whether this target should emit RunfilesGroupInfo.
+
+    Args:
+      ctx: (RuleContext) The context of the rule being evaluated.
+
+    Returns:
+      (bool) True if the global switch is on and the rule can read it.
+    """
+
+    # bazel_java_library_rule and bazel_java_import_rule are entry points for
+    # other rulesets' rule implementations, which may not have merged
+    # RUNFILES_GROUP_ATTRS into their attrs. Treat a missing attribute as "off"
+    # instead of failing their analysis.
+    return hasattr(ctx.attr, "_runfiles_group_enabled") and runfiles_groups.is_enabled(ctx)
+
+def collect_entries(ctx, *, deps, data, own):
+    """Returns the runfiles group entries of a target and of its dependencies.
+
+    Dependencies that provide RunfilesGroupInfo propagate their entries by
+    reference. Those that do not get one synthesized entry each: unlike a
+    ruleset whose own rules all speak the protocol, a Java target's dependency
+    may well be a custom rule that returns JavaInfo - and lands in a binary's
+    runtime classpath and runfiles - without returning RunfilesGroupInfo. Not
+    covering those would silently drop their files from every group.
+
+    Args:
+      ctx: (RuleContext) Used to synthesize entries and to read the providers.
+      deps: (list[Target|list[Target]]) Attribute values holding the
+        dependencies whose groups this target propagates.
+      data: (list[Target|list[Target]]) Attribute values holding arbitrary
+        targets, passed through to runfiles_groups.collect().
+      own: (list[entry]) The entries this target owns.
+
+    Returns:
+      (depset[entry]) The entries of this target and of its dependencies.
+    """
+    participating = []
+    entries = list(own)
+    for dep in _targets(deps):
+        if RunfilesGroupInfo in dep:
+            participating.append(dep)
+        else:
+            entry = _foreign_entry(ctx, dep)
+            if entry:
+                entries.append(entry)
+
+    return runfiles_groups.collect(
+        ctx,
+        deps = participating,
+        data = data,
+        own = entries,
+    )
+
+def _targets(attr_values):
+    """Flattens attribute values holding a single Target or a list of them."""
+    targets = []
+    for value in attr_values:
+        if type(value) == "Target":
+            targets.append(value)
+        else:
+            targets.extend(value)
+    return targets
+
+def _foreign_entry(ctx, dep):
+    """Synthesizes the entry of a dependency that provides no runfiles groups.
+
+    It covers the two channels a Java target draws a dependency's runfiles from:
+    the runtime classpath, built from the dependency's transitive runtime jars,
+    and the dependency's own default runfiles, which a target collects
+    implicitly. Both are empty for a neverlink dependency, which contributes
+    nothing at runtime and therefore needs no group.
+
+    Deliberately not DefaultInfo.files, which runfiles_groups.data_entry() would
+    include: a neverlink java_library publishes its jars there while
+    contributing nothing to a binary's runfiles, and a group holding a file that
+    is not in the runfiles is as wrong as one missing a file that is.
+
+    Args:
+      ctx: (RuleContext) Used to union the two content forms.
+      dep: (Target) A dependency without RunfilesGroupInfo.
+
+    Returns:
+      (entry|None) The dependency's entry, or None if it contributes nothing.
+    """
+    contents = []
+    if JavaInfo in dep:
+        contents.append(dep[JavaInfo].transitive_runtime_jars)
+    default_runfiles = dep[DefaultInfo].default_runfiles
+    if default_runfiles != None:
+        contents.append(default_runfiles)
+    if not contents:
+        return None
+
+    return runfiles_groups.entry(
+        name = dep.label,
+        content = runfiles_groups.union(ctx, contents),
+        merge_affinity = MERGE_AFFINITY,
+    )

--- a/java/common/rules/java_import.bzl
+++ b/java/common/rules/java_import.bzl
@@ -124,5 +124,14 @@ This corresponds to the javac and JVM --add-opens= flags.
         """,
     ),
     "licenses": attr.license() if hasattr(attr, "license") else attr.string_list(),
+    "runfiles_weight": attr.int(
+        default = 0,
+        doc = """
+Weight hint for the target's runfiles group entry. If set to a value greater
+than 0, this weight is attached to the target's runfiles group to help packaging
+rules make informed merge decisions. Intended to be set by dependency management
+rulesets (e.g. rules_jvm_external) using actual jar byte sizes.
+        """,
+    ),
     "_java_toolchain_type": attr.label(default = semantics.JAVA_TOOLCHAIN_TYPE),
 }

--- a/java/rules_java_deps.bzl
+++ b/java/rules_java_deps.bzl
@@ -159,6 +159,15 @@ def bazel_skylib_repo():
         ],
     )
 
+def rules_runfiles_group_repo():
+    maybe(
+        http_archive,
+        name = "rules_runfiles_group",
+        sha256 = "a2e1d6121419ce57f3a22a12a71cbfc985fbdd983242f680801510ba2a482650",
+        strip_prefix = "rules_runfiles_group-0.1.0",
+        urls = ["https://github.com/bazel-contrib/rules_runfiles_group/releases/download/v0.1.0/rules_runfiles_group-v0.1.0.tar.gz"],
+    )
+
 def platforms_repo():
     maybe(
         http_archive,
@@ -231,6 +240,7 @@ def rules_java_dependencies():
     """
     compatibility_proxy_repo()
     bazel_skylib_repo()
+    rules_runfiles_group_repo()
     rules_cc_repo()
     protobuf_repo()
     platforms_repo()

--- a/test/java/bazel/rules/BUILD.bazel
+++ b/test/java/bazel/rules/BUILD.bazel
@@ -2,6 +2,7 @@ load(":java_binary_tests.bzl", "java_binary_tests")
 load(":java_library_tests.bzl", "java_library_tests")
 load(":java_plugin_tests.bzl", "java_plugin_tests")
 load(":java_test_tests.bzl", "java_test_tests")
+load(":runfiles_group_tests.bzl", "runfiles_group_tests")
 
 java_binary_tests(name = "java_binary_tests")
 
@@ -10,3 +11,5 @@ java_library_tests(name = "java_library_tests")
 java_plugin_tests(name = "java_plugin_tests")
 
 java_test_tests(name = "java_test_tests")
+
+runfiles_group_tests(name = "runfiles_group_tests")

--- a/test/java/bazel/rules/runfiles_group_tests.bzl
+++ b/test/java/bazel/rules/runfiles_group_tests.bzl
@@ -1,0 +1,299 @@
+"""Tests for RunfilesGroupInfo support in java rules."""
+
+load("@bazel_features//private:util.bzl", "ge")  # buildifier: disable=bzl-visibility
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("@rules_runfiles_group//runfiles_group:runfiles_group_analysis_test.bzl", "runfiles_group_analysis_test")
+load("//java:java_binary.bzl", "java_binary")
+load("//java:java_import.bzl", "java_import")
+load("//java:java_library.bzl", "java_library")
+load("//java:java_test.bzl", "java_test")
+load("//java/common:java_info.bzl", "JavaInfo")
+load("//java/common/rules/impl:runfiles_group_support.bzl", "own_kind")
+
+# RunfilesGroupInfo is only produced by the Starlark Java rules, which are used
+# on Bazel 8 and newer. On Bazel 7 the native Java rules are used instead (and
+# java_import has no runfiles_weight attribute), so there is nothing to test.
+_STARLARK_JAVA_RULES = ge("8.0.0")
+
+def _fake_jvm_import_impl(ctx):
+    jar = ctx.file.jar
+    return [
+        DefaultInfo(files = depset([jar]), runfiles = ctx.runfiles(files = [jar])),
+        JavaInfo(output_jar = jar, compile_jar = jar),
+    ]
+
+# A stand-in for a custom rule that returns the rules_java providers but no
+# RunfilesGroupInfo, e.g. rules_jvm_external's jvm_import. The java rules have to
+# synthesize a group for such a dependency, or a packager would find no group
+# holding its jars.
+_fake_jvm_import = rule(
+    implementation = _fake_jvm_import_impl,
+    attrs = {"jar": attr.label(allow_single_file = True, mandatory = True)},
+)
+
+def _helper(rule_fn, name, **kwargs):
+    rule_fn(name = name, tags = ["manual"], **kwargs)
+
+def _own_kind_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "first_party", own_kind(Label("//java/com/example:lib")))
+
+    # Java code Bazel builds from source in another module -- the protobuf
+    # runtime, say -- is not the user's own code.
+    asserts.equals(env, "third_party", own_kind(Label("@other_repo//:lib")))
+
+    return unittest.end(env)
+
+_own_kind_test = unittest.make(_own_kind_impl)
+
+def _label_str(name):
+    """The canonical string form of a target's label, as the test reports it."""
+    return str(native.package_relative_label(":" + name))
+
+def runfiles_group_tests(name):
+    """Registers the RunfilesGroupInfo tests and a test_suite that bundles them.
+
+    Args:
+        name: Name of the generated test_suite; also used as a prefix for the
+            individual analysis test targets.
+    """
+    if not _STARLARK_JAVA_RULES:
+        native.test_suite(name = name, tests = [])
+        return
+
+    tests = [
+        "own_kind",
+        "simple_binary",
+        "transitive_deps",
+        "runtime_deps",
+        "java_import",
+        "java_import_weight",
+        "with_data",
+        "library_with_data",
+        "foreign_java_dep",
+        "java_test",
+        "group_ordering",
+        "merge_to_limit",
+    ]
+
+    _own_kind_test(name = name + "/own_kind")
+    _test_simple_binary(name + "/simple_binary")
+    _test_binary_with_transitive_deps(name + "/transitive_deps")
+    _test_binary_with_runtime_deps(name + "/runtime_deps")
+    _test_binary_with_java_import(name + "/java_import")
+    _test_binary_with_java_import_weight(name + "/java_import_weight")
+    _test_binary_with_data(name + "/with_data")
+    _test_library_with_data(name + "/library_with_data")
+    _test_binary_with_foreign_java_dep(name + "/foreign_java_dep")
+    _test_java_test_rule(name + "/java_test")
+    _test_binary_group_ordering(name + "/group_ordering")
+    _test_merge_to_limit(name + "/merge_to_limit")
+
+    native.test_suite(
+        name = name,
+        tests = [name + "/" + test for test in tests],
+    )
+
+def _test_simple_binary(name):
+    _helper(java_library, name + "_lib", srcs = ["java/A.java"])
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "A",
+        runtime_deps = [name + "_lib"],
+    )
+
+    # The only test that keeps check_disabled = True: it analyzes the binary's
+    # entire closure a second time to verify that the rules honor the global
+    # switch, which is worth doing once rather than in every case.
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        expected_executable_group = "rules_java#binary",
+    )
+
+def _test_binary_with_transitive_deps(name):
+    _helper(java_library, name + "_leaf", srcs = ["java/A.java"])
+    _helper(java_library, name + "_mid", srcs = ["java/B.java"], deps = [name + "_leaf"])
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "B",
+        runtime_deps = [name + "_mid"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+    )
+
+def _test_binary_with_runtime_deps(name):
+    _helper(java_library, name + "_compile_dep", srcs = ["java/A.java"])
+    _helper(java_library, name + "_runtime_dep", srcs = ["java/B.java"])
+    _helper(
+        java_binary,
+        name + "_bin",
+        srcs = ["java/Main.java"],
+        main_class = "Main",
+        deps = [name + "_compile_dep"],
+        runtime_deps = [name + "_runtime_dep"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+    )
+
+def _test_binary_with_java_import(name):
+    _helper(
+        java_import,
+        name + "_imported",
+        jars = ["B.jar"],
+    )
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "A",
+        runtime_deps = [name + "_imported"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+    )
+
+def _test_binary_with_java_import_weight(name):
+    _helper(
+        java_import,
+        name + "_imported",
+        jars = ["B.jar"],
+        runfiles_weight = 42,
+    )
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "A",
+        runtime_deps = [name + "_imported"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+    )
+
+def _test_binary_with_data(name):
+    _helper(java_library, name + "_lib", srcs = ["java/A.java"])
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "A",
+        runtime_deps = [name + "_lib"],
+        data = ["java/A.java"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+    )
+
+def _test_library_with_data(name):
+    # A library's data files land in the binary's runfiles through
+    # collect_default, so the library has to put them in a group of their own.
+    _helper(java_library, name + "_lib", srcs = ["java/A.java"], data = ["java/A.java"])
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "A",
+        runtime_deps = [name + "_lib"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+    )
+
+def _test_binary_with_foreign_java_dep(name):
+    _helper(_fake_jvm_import, name + "_foreign", jar = "B.jar")
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "A",
+        runtime_deps = [name + "_foreign"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+    )
+
+def _test_java_test_rule(name):
+    _helper(java_library, name + "_lib", srcs = ["java/A.java"])
+    _helper(
+        java_test,
+        name + "_test_bin",
+        srcs = ["java/A.java"],
+        test_class = "A",
+        runtime_deps = [name + "_lib"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_test_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+    )
+
+def _test_binary_group_ordering(name):
+    _helper(java_library, name + "_lib", srcs = ["java/A.java"])
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "A",
+        runtime_deps = [name + "_lib"],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+        # The java_runtime is at the foundation rank, everything else at the
+        # executable rank, where the per-target groups (named by a Label) sort
+        # before the named ones.
+        expected_group_names = [
+            "rules_java#java_runtime",
+            _label_str(name + "_bin"),
+            _label_str(name + "_lib"),
+            "rules_java#binary",
+        ],
+    )
+
+def _test_merge_to_limit(name):
+    _helper(java_library, name + "_lib_a", srcs = ["java/A.java"])
+    _helper(java_library, name + "_lib_b", srcs = ["java/B.java"])
+    _helper(java_library, name + "_lib_c", srcs = ["java/C.java"])
+    _helper(
+        java_binary,
+        name + "_bin",
+        main_class = "A",
+        runtime_deps = [
+            name + "_lib_a",
+            name + "_lib_b",
+            name + "_lib_c",
+        ],
+    )
+    runfiles_group_analysis_test(
+        name = name,
+        binaries = [name + "_bin"],
+        overlapping_group_behavior = "error",
+        check_disabled = False,
+        max_groups = 4,
+        expected_group_count = 4,
+    )

--- a/test/repo/.bazelrc
+++ b/test/repo/.bazelrc
@@ -2,6 +2,12 @@ build:bzlmod --experimental_enable_bzlmod
 
 common --incompatible_disallow_empty_glob
 
+# rules_runfiles_group (loaded by the java rule implementations) must be excluded
+# from autoloads to avoid a load cycle in WORKSPACE mode on Bazel 8. On Bazel
+# 8.0.0-8.3.0 the same applies to bazel_features' generated repos.
+# https://github.com/bazelbuild/bazel/issues/23043
+common --repositories_without_autoloads=rules_runfiles_group,bazel_features_version,bazel_features_globals
+
 # Enable modern C++ features, for compiling java_tools from source
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17


### PR DESCRIPTION
Teach the Java rules to describe their runfiles as named, ordered groups so that downstream packaging rules can build more efficient artifacts.

`java_binary`, `java_test`, `java_library`, and `java_import` now return `RunfilesGroupInfo` (and `RunfilesGroupMetadataInfo`) from the `rules_runfiles_group` ruleset alongside `DefaultInfo`. Instead of seeing a single flat runfiles tree, a packaging rule (e.g. a container-image or archive rule) can split a binary's runfiles into layers and order them so that the content that changes least often lands in the most cacheable layers:

  * the JDK / java_runtime at the foundation tier (never merged),
  * `java_import` targets (typically third-party jars) at the shared-deps tier,
  * first-party `java_library` code, the binary's own jars, and the executable at the executable tier.

Libraries propagate fine-grained per-target groups up through their dependents; the binary collects them, adds its own groups, and tags every group it produces with the `rules_java` merge affinity so that JVM-shaped groups stay together when a packager has to merge groups to fit a layer limit. `java_import` gains a `runfiles_weight` attribute so dependency-management rulesets can hint at relative sizes to guide those merge decisions.

Consumers that don't understand `RunfilesGroupInfo` are unaffected and keep using `DefaultInfo.default_runfiles`.

Adds a dependency on `rules_runfiles_group` for both Bzlmod and WORKSPACE setups.

## Validation

I took the liberty to host a [BCR mirror that has support enabled for rules_java and rules_img](https://bazel-contrib.github.io/rules_runfiles_group/). I also created a [demo repo to show the effect](https://github.com/malt3/runfiles_group_demo).

This shows two `java_binary` targets with overlapping dependencies. Both are packaged as container images.
Without `RunfilesGroupInfo`, the whole `java_binary` is stored as a single layer and there is no sharing (only the base image layer is shared):

<img width="4138" height="2620" src="https://github.com/user-attachments/assets/7ed21f46-cd19-4185-b030-591fdc809d22" />

With `RunfilesGroupInfo`, individual runfiles from `java_library` targets get their own layers and most of the content is shared across the container images:

<img width="5064" height="3326" src="https://github.com/user-attachments/assets/323b509f-0717-4938-bb6d-473ff2c8a747" />

