### PR TITLE
Delete downloaded archive after hashing in dump_remote_jdk_configs

### DIFF
--- a/java/bazel/BUILD.bazel
+++ b/java/bazel/BUILD.bazel
@@ -39,6 +39,7 @@ while read -r config; do
     echo "  urls = $$urls,"
     echo "  version = \\"$$version\\","
     echo "),"
+    rm -f "$$TMP_FILE"
 done <<< '{configs}' >> $@
     """.format(configs = "\n".join([
         "|".join([


### PR DESCRIPTION
The dump_remote_jdk_configs genrule downloads each remote JDK archive to a per-iteration mktemp file to compute its sha256, but never removes it. A full run fetches every configured JDK (all versions and platforms, ~200 MB each), so it leaves roughly 7 GB of archives behind in /tmp.

Remove the temp file at the end of each loop iteration, keeping peak /tmp usage to a single archive instead of the whole set.
