### PR TITLE
Read and write the regular runfiles variables

### DIFF
--- a/java/bazel/rules/java_stub_template.txt
+++ b/java/bazel/rules/java_stub_template.txt
@@ -193,15 +193,26 @@ if is_windows; then
 fi
 
 export JAVA_RUNFILES
-export RUNFILES_MANIFEST_FILE="${JAVA_RUNFILES}/MANIFEST"
-export RUNFILES_MANIFEST_ONLY=%runfiles_manifest_only%
+# Runfiles libraries look up the runfiles directory in RUNFILES_DIR; JAVA_RUNFILES is only still
+# exported for the benefit of this script and of tools that predate RUNFILES_DIR.
+export RUNFILES_DIR="$JAVA_RUNFILES"
+# %runfiles_manifest_only% is derived from --enable_runfiles, which doesn't account for the runfiles
+# directory being materialized by the sandbox or by remote execution. Only ask subprocesses to use
+# the manifest if it has actually been staged, and tell them to use the runfiles directory otherwise.
+if [[ "%runfiles_manifest_only%" == 1 && -e "${JAVA_RUNFILES}/MANIFEST" ]]; then
+  export RUNFILES_MANIFEST_FILE="${JAVA_RUNFILES}/MANIFEST"
+  export RUNFILES_MANIFEST_ONLY=1
+else
+  export RUNFILES_MANIFEST_FILE=
+  export RUNFILES_MANIFEST_ONLY=
+fi
 
 if [ -z "$RUNFILES_MANIFEST_ONLY" ]; then
   function rlocation() {
     if [[ "$1" = /* ]]; then
       echo $1
     else
-      echo "$(dirname $RUNFILES_MANIFEST_FILE)/$1"
+      echo "${JAVA_RUNFILES}/$1"
     fi
   }
 else

--- a/java/runfiles/src/main/java/com/google/devtools/build/runfiles/Runfiles.java
+++ b/java/runfiles/src/main/java/com/google/devtools/build/runfiles/Runfiles.java
@@ -528,10 +528,15 @@ public final class Runfiles {
 
     @Override
     protected Map<String, String> getEnvVars() {
-      HashMap<String, String> result = new HashMap<>(2);
+      HashMap<String, String> result = new HashMap<>(4);
       result.put("RUNFILES_DIR", runfilesRoot);
       // TODO(laszlocsomor): remove JAVA_RUNFILES once the Java launcher can pick up RUNFILES_DIR.
       result.put("JAVA_RUNFILES", runfilesRoot);
+      // Clear values inherited from an ancestor process, which describe how that process' runfiles
+      // were staged and not how this process' runfiles were. Since the variables are set to the
+      // empty string rather than to a path, a subprocess that doesn't recognize them is unaffected.
+      result.put("RUNFILES_MANIFEST_FILE", "");
+      result.put("RUNFILES_MANIFEST_ONLY", "");
       return result;
     }
   }

--- a/java/runfiles/src/main/java/com/google/devtools/build/runfiles/Runfiles.java
+++ b/java/runfiles/src/main/java/com/google/devtools/build/runfiles/Runfiles.java
@@ -248,30 +248,49 @@ public final class Runfiles {
    *   <li>directory-based, meaning it looks up runfile paths under a given directory path
    * </ul>
    *
-   * <p>If {@code env} contains "RUNFILES_MANIFEST_ONLY" with value "1", this method returns a
-   * manifest-based implementation. The manifest's path is defined by the "RUNFILES_MANIFEST_FILE"
-   * key's value in {@code env}.
+   * <p>If {@code env} contains "RUNFILES_MANIFEST_FILE" and it points to an existing file, this
+   * method returns a manifest-based implementation backed by that file.
    *
-   * <p>Otherwise this method returns a directory-based implementation. The directory's path is
-   * defined by the value in {@code env} under the "RUNFILES_DIR" key, or if absent, then under the
-   * "JAVA_RUNFILES" key.
+   * <p>Otherwise, if {@code env} contains "RUNFILES_DIR" (or, if absent, "JAVA_RUNFILES") and it
+   * points to an existing directory, this method returns a directory-based implementation backed by
+   * that directory.
    *
    * <p>Note about performance: the manifest-based implementation eagerly reads and caches the whole
    * manifest file upon instantiation.
    *
-   * @throws java.io.IOException if RUNFILES_MANIFEST_ONLY=1 is in {@code env} but there's no
-   *     "RUNFILES_MANIFEST_FILE", "RUNFILES_DIR", or "JAVA_RUNFILES" key in {@code env} or their
-   *     values are empty, or some IO error occurs
+   * @throws java.io.IOException if neither a runfiles manifest nor a runfiles directory could be
+   *     found, or some IO error occurs
    */
   public static Preloaded preload(Map<String, String> env) throws IOException {
-    if (isManifestOnly(env)) {
-      // On Windows, Bazel sets RUNFILES_MANIFEST_ONLY=1.
-      // On every platform, Bazel also sets RUNFILES_MANIFEST_FILE, but on Linux and macOS it's
-      // faster to use RUNFILES_DIR.
-      return new ManifestBased(getManifestPath(env));
-    } else {
-      return new DirectoryBased(getRunfilesDir(env));
+    // A manifest and a directory may both be named: the process that set up the environment knows
+    // which of the two it staged, and communicates that by only naming the one that is usable.
+    // Values that name something that isn't there are dropped rather than trusted, since a launcher
+    // or parent process may have derived them from a build-time flag that doesn't account for the
+    // runfiles directory having been materialized by the sandbox or by remote execution.
+    String manifestPathValue = env.get("RUNFILES_MANIFEST_FILE");
+    String runfilesDirValue = env.get("RUNFILES_DIR");
+    if (Util.isNullOrEmpty(runfilesDirValue)) {
+      // The java_binary launcher script only exports JAVA_RUNFILES, so for a process it starts,
+      // this is the only variable that names the runfiles directory.
+      runfilesDirValue = env.get("JAVA_RUNFILES");
     }
+
+    boolean hasManifest =
+        !Util.isNullOrEmpty(manifestPathValue) && new File(manifestPathValue).isFile();
+    boolean hasDirectory =
+        !Util.isNullOrEmpty(runfilesDirValue) && new File(runfilesDirValue).isDirectory();
+
+    if (hasManifest) {
+      return new ManifestBased(manifestPathValue, hasDirectory ? runfilesDirValue : null);
+    }
+    if (hasDirectory) {
+      return new DirectoryBased(runfilesDirValue);
+    }
+    throw new IOException(
+        String.format(
+            "Cannot find runfiles: $RUNFILES_MANIFEST_FILE (%s) does not name an existing file and"
+                + " $RUNFILES_DIR / $JAVA_RUNFILES (%s) does not name an existing directory",
+            manifestPathValue, runfilesDirValue));
   }
 
   /**
@@ -297,20 +316,13 @@ public final class Runfiles {
    *   <li>directory-based, meaning it looks up runfile paths under a given directory path
    * </ul>
    *
-   * <p>If {@code env} contains "RUNFILES_MANIFEST_ONLY" with value "1", this method returns a
-   * manifest-based implementation. The manifest's path is defined by the "RUNFILES_MANIFEST_FILE"
-   * key's value in {@code env}.
-   *
-   * <p>Otherwise this method returns a directory-based implementation. The directory's path is
-   * defined by the value in {@code env} under the "RUNFILES_DIR" key, or if absent, then under the
-   * "JAVA_RUNFILES" key.
+   * <p>See {@link #preload(java.util.Map)} for how the implementation is chosen.
    *
    * <p>Note about performance: the manifest-based implementation eagerly reads and caches the whole
    * manifest file upon instantiation.
    *
-   * @throws IOException if RUNFILES_MANIFEST_ONLY=1 is in {@code env} but there's no
-   *     "RUNFILES_MANIFEST_FILE", "RUNFILES_DIR", or "JAVA_RUNFILES" key in {@code env} or their
-   *     values are empty, or some IO error occurs
+   * @throws IOException if neither a runfiles manifest nor a runfiles directory could be found, or
+   *     some IO error occurs
    * @deprecated Use {@link #preload(java.util.Map)} instead. With {@code --enable_bzlmod}, this
    *     function does not work correctly.
    */
@@ -380,44 +392,20 @@ public final class Runfiles {
             apparentRepositoryName);
   }
 
-  /** Returns true if the platform supports runfiles only via manifests. */
-  private static boolean isManifestOnly(Map<String, String> env) {
-    return "1".equals(env.get("RUNFILES_MANIFEST_ONLY"));
-  }
-
-  private static String getManifestPath(Map<String, String> env) throws IOException {
-    String value = env.get("RUNFILES_MANIFEST_FILE");
-    if (Util.isNullOrEmpty(value)) {
-      throw new IOException(
-          "Cannot load runfiles manifest: $RUNFILES_MANIFEST_ONLY is 1 but"
-              + " $RUNFILES_MANIFEST_FILE is empty or undefined");
-    }
-    return value;
-  }
-
-  private static String getRunfilesDir(Map<String, String> env) throws IOException {
-    String value = env.get("RUNFILES_DIR");
-    if (Util.isNullOrEmpty(value)) {
-      value = env.get("JAVA_RUNFILES");
-    }
-    if (Util.isNullOrEmpty(value)) {
-      throw new IOException(
-          "Cannot find runfiles: $RUNFILES_DIR and $JAVA_RUNFILES are both unset or empty");
-    }
-    return value;
-  }
-
   /** {@link Runfiles} implementation that parses a runfiles-manifest file to look up runfiles. */
   private static final class ManifestBased extends Preloaded {
 
     private final Map<String, String> runfiles;
     private final String manifestPath;
+    private final String runfilesDir;
     private final RepositoryMapping repoMapping;
 
-    ManifestBased(String manifestPath) throws IOException {
+    ManifestBased(String manifestPath, String runfilesDir) throws IOException {
       Util.checkArgument(manifestPath != null);
       Util.checkArgument(!manifestPath.isEmpty());
       this.manifestPath = manifestPath;
+      this.runfilesDir =
+          Util.isNullOrEmpty(runfilesDir) ? findRunfilesDir(manifestPath) : runfilesDir;
       this.runfiles = loadRunfiles(manifestPath);
       this.repoMapping = RepositoryMapping.readFromFile(rlocationChecked("_repo_mapping"));
     }
@@ -444,9 +432,12 @@ public final class Runfiles {
     @Override
     protected Map<String, String> getEnvVars() {
       HashMap<String, String> result = new HashMap<>(4);
-      result.put("RUNFILES_MANIFEST_ONLY", "1");
       result.put("RUNFILES_MANIFEST_FILE", manifestPath);
-      String runfilesDir = findRunfilesDir(manifestPath);
+      // Runfiles libraries that decide between the two implementations based on this variable
+      // instead of on which of the other two names an existing path need it to use the manifest.
+      result.put("RUNFILES_MANIFEST_ONLY", "1");
+      // The runfiles directory is not fully materialized in this case, but language launchers locate
+      // their own runtime data relative to it, so pass it on if it is known.
       result.put("RUNFILES_DIR", runfilesDir);
       // TODO(laszlocsomor): remove JAVA_RUNFILES once the Java launcher can pick up RUNFILES_DIR.
       result.put("JAVA_RUNFILES", runfilesDir);
@@ -546,7 +537,7 @@ public final class Runfiles {
   }
 
   static Preloaded createManifestBasedForTesting(String manifestPath) throws IOException {
-    return new ManifestBased(manifestPath);
+    return new ManifestBased(manifestPath, /* runfilesDir= */ null);
   }
 
   static Preloaded createDirectoryBasedForTesting(String runfilesDir) throws IOException {

--- a/test/java/runfiles/src/test/java/com/google/devtools/build/runfiles/RunfilesTest.java
+++ b/test/java/runfiles/src/test/java/com/google/devtools/build/runfiles/RunfilesTest.java
@@ -76,12 +76,17 @@ public final class RunfilesTest {
   @Test
   public void testCreatesManifestBasedRunfiles() throws Exception {
     Path mf = tempFile("foo.runfiles_manifest", ImmutableList.of("a/b c/d"));
+    Path dir =
+        Files.createTempDirectory(
+            FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR")), null);
+
+    // The manifest takes precedence over the runfiles directory: whoever set up the environment
+    // only names the manifest if the runfiles directory hasn't been fully materialized.
     Runfiles r =
         Runfiles.create(
             ImmutableMap.of(
-                "RUNFILES_MANIFEST_ONLY", "1",
                 "RUNFILES_MANIFEST_FILE", mf.toString(),
-                "RUNFILES_DIR", "ignored when RUNFILES_MANIFEST_ONLY=1",
+                "RUNFILES_DIR", dir.toString(),
                 "JAVA_RUNFILES", "ignored when RUNFILES_DIR has a value",
                 "TEST_SRCDIR", "should always be ignored"));
     assertThat(r.rlocation("a/b")).isEqualTo("c/d");
@@ -96,6 +101,19 @@ public final class RunfilesTest {
   }
 
   @Test
+  public void testCreatesManifestBasedRunfilesWithoutManifestOnly() throws Exception {
+    // RUNFILES_MANIFEST_ONLY is not consulted: it is derived from --enable_runfiles at analysis
+    // time, which doesn't account for how the runfiles were staged for this particular process.
+    Path mf = tempFile("foo.runfiles_manifest", ImmutableList.of("a/b c/d"));
+    Runfiles r =
+        Runfiles.create(
+            ImmutableMap.of(
+                "RUNFILES_MANIFEST_ONLY", "",
+                "RUNFILES_MANIFEST_FILE", mf.toString()));
+    assertThat(r.rlocation("a/b")).isEqualTo("c/d");
+  }
+
+  @Test
   public void testCreatesDirectoryBasedRunfiles() throws Exception {
     Path dir =
         Files.createTempDirectory(
@@ -104,7 +122,6 @@ public final class RunfilesTest {
     Runfiles r =
         Runfiles.create(
             ImmutableMap.of(
-                "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
                 "RUNFILES_DIR", dir.toString(),
                 "JAVA_RUNFILES", "ignored when RUNFILES_DIR has a value",
                 "TEST_SRCDIR", "should always be ignored"));
@@ -114,12 +131,28 @@ public final class RunfilesTest {
     r =
         Runfiles.create(
             ImmutableMap.of(
-                "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
                 "RUNFILES_DIR", "",
                 "JAVA_RUNFILES", dir.toString(),
                 "TEST_SRCDIR", "should always be ignored"));
     assertThat(r.rlocation("a/b")).endsWith("/a/b");
     assertThat(r.rlocation("foo")).endsWith("/foo");
+  }
+
+  @Test
+  public void testCreatesDirectoryBasedRunfilesWithMissingManifest() throws Exception {
+    // The sandbox and remote execution materialize the runfiles directory without staging the
+    // manifest, even though a launcher or parent process may have named one.
+    Path dir =
+        Files.createTempDirectory(
+            FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR")), null);
+
+    Runfiles r =
+        Runfiles.create(
+            ImmutableMap.of(
+                "RUNFILES_MANIFEST_ONLY", "1",
+                "RUNFILES_MANIFEST_FILE", dir.resolve("MANIFEST").toString(),
+                "RUNFILES_DIR", dir.toString()));
+    assertThat(r.rlocation("a/b")).isEqualTo(dir + "/a/b");
   }
 
   @Test
@@ -131,13 +164,11 @@ public final class RunfilesTest {
     Runfiles.create(
         ImmutableMap.of(
             "RUNFILES_DIR", dir.toString(),
-            "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
             "TEST_SRCDIR", "should always be ignored"));
 
     Runfiles.create(
         ImmutableMap.of(
             "JAVA_RUNFILES", dir.toString(),
-            "RUNFILES_MANIFEST_FILE", "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
             "TEST_SRCDIR", "should always be ignored"));
 
     IOException e =
@@ -150,24 +181,23 @@ public final class RunfilesTest {
                         "",
                         "JAVA_RUNFILES",
                         "",
-                        "RUNFILES_MANIFEST_FILE",
-                        "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
                         "TEST_SRCDIR",
                         "should always be ignored")));
-    assertThat(e).hasMessageThat().contains("$RUNFILES_DIR and $JAVA_RUNFILES");
+    assertThat(e).hasMessageThat().contains("$RUNFILES_DIR / $JAVA_RUNFILES");
   }
 
   @Test
-  public void testFailsToCreateManifestBasedBecauseManifestDoesNotExist() {
+  public void testFailsToCreateBecauseNeitherManifestNorDirectoryExists() {
     IOException e =
         assertThrows(
             IOException.class,
             () ->
                 Runfiles.create(
                     ImmutableMap.of(
-                        "RUNFILES_MANIFEST_ONLY", "1",
-                        "RUNFILES_MANIFEST_FILE", "non-existing path")));
-    assertThat(e).hasMessageThat().contains("non-existing path");
+                        "RUNFILES_MANIFEST_FILE", "non-existing manifest",
+                        "RUNFILES_DIR", "non-existing directory")));
+    assertThat(e).hasMessageThat().contains("non-existing manifest");
+    assertThat(e).hasMessageThat().contains("non-existing directory");
   }
 
   @Test
@@ -176,15 +206,14 @@ public final class RunfilesTest {
     Map<String, String> envvars =
         Runfiles.create(
                 ImmutableMap.of(
-                    "RUNFILES_MANIFEST_ONLY", "1",
                     "RUNFILES_MANIFEST_FILE", mf.toString(),
-                    "RUNFILES_DIR", "ignored when RUNFILES_MANIFEST_ONLY=1",
-                    "JAVA_RUNFILES", "ignored when RUNFILES_DIR has a value",
                     "TEST_SRCDIR", "should always be ignored"))
             .getEnvVars();
     assertThat(envvars.keySet())
         .containsExactly(
             "RUNFILES_MANIFEST_ONLY", "RUNFILES_MANIFEST_FILE", "RUNFILES_DIR", "JAVA_RUNFILES");
+    // Subprocesses that don't check whether the runfiles directory has been materialized rely on
+    // RUNFILES_MANIFEST_ONLY to make them use the manifest.
     assertThat(envvars.get("RUNFILES_MANIFEST_ONLY")).isEqualTo("1");
     assertThat(envvars.get("RUNFILES_MANIFEST_FILE")).isEqualTo(mf.toString());
     assertThat(envvars.get("RUNFILES_DIR")).isEqualTo(tempDir.getRoot().toString());
@@ -196,10 +225,7 @@ public final class RunfilesTest {
     envvars =
         Runfiles.create(
                 ImmutableMap.of(
-                    "RUNFILES_MANIFEST_ONLY", "1",
                     "RUNFILES_MANIFEST_FILE", mf.toString(),
-                    "RUNFILES_DIR", "ignored when RUNFILES_MANIFEST_ONLY=1",
-                    "JAVA_RUNFILES", "ignored when RUNFILES_DIR has a value",
                     "TEST_SRCDIR", "should always be ignored"))
             .getEnvVars();
     assertThat(envvars.get("RUNFILES_MANIFEST_ONLY")).isEqualTo("1");
@@ -209,12 +235,30 @@ public final class RunfilesTest {
   }
 
   @Test
+  public void testManifestBasedEnvVarsPassOnTheRunfilesDirectoryFromTheEnvironment()
+      throws Exception {
+    // The runfiles directory doesn't have to be adjacent to the manifest, in which case it can only
+    // be taken from the environment.
+    Path mf = tempFile("manifest_with_unrelated_name", ImmutableList.of());
+    Path dir =
+        Files.createTempDirectory(
+            FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR")), null);
+
+    Map<String, String> envvars =
+        Runfiles.create(
+                ImmutableMap.of(
+                    "RUNFILES_MANIFEST_FILE", mf.toString(),
+                    "RUNFILES_DIR", dir.toString()))
+            .getEnvVars();
+    assertThat(envvars.get("RUNFILES_DIR")).isEqualTo(dir.toString());
+    assertThat(envvars.get("JAVA_RUNFILES")).isEqualTo(dir.toString());
+  }
+
+  @Test
   public void testDirectoryBasedEnvVars() throws Exception {
     Map<String, String> envvars =
         Runfiles.create(
                 ImmutableMap.of(
-                    "RUNFILES_MANIFEST_FILE",
-                    "ignored when RUNFILES_MANIFEST_ONLY is not set to 1",
                     "RUNFILES_DIR",
                     tempDir.getRoot().toString(),
                     "JAVA_RUNFILES",

--- a/test/java/runfiles/src/test/java/com/google/devtools/build/runfiles/RunfilesTest.java
+++ b/test/java/runfiles/src/test/java/com/google/devtools/build/runfiles/RunfilesTest.java
@@ -266,9 +266,15 @@ public final class RunfilesTest {
                     "TEST_SRCDIR",
                     "should always be ignored"))
             .getEnvVars();
-    assertThat(envvars.keySet()).containsExactly("RUNFILES_DIR", "JAVA_RUNFILES");
+    assertThat(envvars.keySet())
+        .containsExactly(
+            "RUNFILES_DIR", "JAVA_RUNFILES", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY");
     assertThat(envvars.get("RUNFILES_DIR")).isEqualTo(tempDir.getRoot().toString());
     assertThat(envvars.get("JAVA_RUNFILES")).isEqualTo(tempDir.getRoot().toString());
+    // Values inherited from an ancestor process must not make a subprocess use a manifest instead
+    // of the fully materialized runfiles directory.
+    assertThat(envvars.get("RUNFILES_MANIFEST_FILE")).isEmpty();
+    assertThat(envvars.get("RUNFILES_MANIFEST_ONLY")).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
Runfiles libraries decide between resolving runfiles paths against the runfiles directory and resolving them through the runfiles manifest. The Java library makes that decision based on `RUNFILES_MANIFEST_ONLY`, which Bazel derives from `--enable_runfiles` alone. That flag is evaluated at analysis time and thus doesn't account for the runfiles directory being materialized by the sandbox or by remote execution, in which case no manifest is staged at all. The `java_binary` launcher script has the same problem, one level out: it bakes the value of the flag into the script and points subprocesses at a manifest that may not be there.

This makes the library read and write the variables that name the runfiles directory and the runfiles manifest, and select the implementation based on which of the two actually exists — the way every other runfiles library does it. Whoever sets up the environment already knows which of the two it staged, and communicates that by naming only the one that is usable, so a value that names something that isn't there is dropped rather than trusted.

Concretely, with `--noenable_runfiles`, a `java_binary` used as a tool of a sandboxed action fails to run today:

```
$ bazel build --noenable_runfiles //:run_as_tool
grep: .../app.runfiles/MANIFEST: No such file or directory
bazel-out/darwin_arm64-opt-exec/bin/app: line 409: exec: : not found
ERROR: Build did NOT complete successfully
```

Both the launcher script and the runfiles library insist on a manifest, while the sandbox has materialized the entire runfiles directory. After this change the same target builds, and the binary resolves its runfiles against the directory.

`RUNFILES_MANIFEST_ONLY` is still *written* by `getEnvVars` and by the launcher script whenever the manifest is the implementation in use, for the benefit of subprocesses whose runfiles library still reads it. It is never propagated from the environment, since an inherited value describes how some ancestor process' runfiles were staged.

The commits are independent and can be taken separately:

1. `Select the runfiles implementation based on the regular runfiles variables` — the read side of the library.
2. `Clear the manifest variables in getEnvVars if the runfiles directory is used` — the write side of the library.
3. `Export the regular runfiles variables from the java_binary launcher` — the launcher script, which is what fixes the failure above end to end.

Follow-up, out of scope here: bazelbuild/bazel is adding a `_runfiles_enabled` marker file to every runfiles tree, which is present if and only if the directory has been fully materialized. With it, the selection can prefer a materialized runfiles directory over an available manifest instead of the other way around, which avoids parsing a manifest that isn't needed. That is a one-line addition on top of this change and needs a Bazel release that stages the marker.

Tested manually on macOS with `bazel run`, `bazel run --noenable_runfiles`, `bazel build` of a genrule whose tool is a `java_binary` (sandboxed, with and without `--noenable_runfiles`), plus the new unit tests. `//test/...` passes.
