### PR TITLE
Silence protobuf sun.misc.Unsafe warnings from the direct header comp…

### DIFF
--- a/java/common/rules/java_toolchain.bzl
+++ b/java/common/rules/java_toolchain.bzl
@@ -91,6 +91,9 @@ def _java_toolchain_impl(ctx):
     else:
         header_compiler_direct_data = []
         header_compiler_direct_jvm_opts = []
+
+    header_compiler_direct_jvm_opts = header_compiler_direct_jvm_opts + ctx.attr.header_compiler_direct_opts
+
     if ctx.attr.oneversion_allowlist and ctx.attr.oneversion_whitelist:
         fail("oneversion_allowlist and oneversion_whitelist are mutually exclusive")
     oneversion_allowlist = ctx.file.oneversion_allowlist if ctx.file.oneversion_allowlist else ctx.file.oneversion_whitelist
@@ -586,6 +589,18 @@ Labels of data available for label-expansion in turbine_jvm_opts.
         "turbine_jvm_opts": attr.string_list(
             doc = """
 The list of arguments for the JVM when invoking turbine.
+            """,
+        ),
+        "header_compiler_direct_opts": attr.string_list(
+            doc = """
+Additional options passed to the direct header compiler, verbatim and without
+location or make-variable expansion.
+
+Warning: these are only meaningful when the direct header compiler runs on a
+JVM, such as TurbineDirect's deploy jar. A native direct header compiler such
+as turbine_direct_graal parses them as Turbine command-line options, so do not
+set JVM options (for example --sun-misc-unsafe-memory-access=allow) when a
+native direct header compiler is in use.
             """,
         ),
         "xlint": attr.string_list(


### PR DESCRIPTION
…iler

turbine_direct (header_compiler_direct) bundles protobuf, whose UnsafeUtil calls terminally-deprecated sun.misc.Unsafe methods. On JDK 24+ (JEP 498) the JVM prints a warning for each such call during header compilation:

  WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
  WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by
  com.google.protobuf.UnsafeUtil (.../java_tools/turbine_direct_binary_deploy.jar)

Unlike the Turbine worker, header_compiler_direct does not receive turbine_jvm_opts, and --jvmopt does not reach header-compilation actions, so a toolchain currently has no way to silence these warnings for the direct header compiler. Add --sun-misc-unsafe-memory-access=allow to header_compiler_direct_jvm_opts, gated on the runtime feature version since the flag is rejected on JDK <= 22.

See https://github.com/protocolbuffers/protobuf/issues/20760.

Closes #374