### PR TITLE
Apply execution requirements only to Java test runs

### DIFF
--- a/java/common/rules/impl/java_binary_impl.bzl
+++ b/java/common/rules/impl/java_binary_impl.bzl
@@ -473,8 +473,11 @@ def _auto_create_deploy_jar(ctx, info, launcher_info, main_class, coverage_main_
 
 def _test_providers(ctx):
     test_providers = []
+    execution_requirements = dict(ctx.attr.execution_requirements)
     if helper.has_target_constraints(ctx, ctx.attr._apple_constraints):
-        test_providers.append(testing.ExecutionInfo({"requires-darwin": ""}))
+        execution_requirements["requires-darwin"] = ""
+    if execution_requirements:
+        test_providers.append(testing.ExecutionInfo(execution_requirements))
 
     test_env = {}
     test_env.update(cc_helper.get_expanded_env(ctx, {}))

--- a/java/common/rules/java_binary.bzl
+++ b/java/common/rules/java_binary.bzl
@@ -360,6 +360,12 @@ The Java class to be loaded by the test runner.<br/>
 </p>
         """,
     ),
+    "execution_requirements": attr.string_dict(
+        doc = """
+Execution requirements applied only when running the test, rather than to
+every action that builds the test target.
+        """,
+    ),
     "env_inherit": attr.string_list(),
     "_apple_constraints": attr.label_list(
         default = [

--- a/test/java/common/rules/java_test_tests.bzl
+++ b/test/java/common/rules/java_test_tests.bzl
@@ -209,6 +209,25 @@ def _test_stamp_values_impl(env, targets):
     env.expect.that_target(targets.defaultstamp).attr("stamp", factory = subjects.int).equals(0)
     env.expect.that_target(targets.autostamp).attr("stamp", factory = subjects.int).equals(-1)
 
+def _test_execution_requirements(name):
+    util.helper_target(
+        rule = java_test,
+        name = name + "/test",
+        srcs = [name + "/Test.java"],
+        execution_requirements = {"requires-network": ""},
+    )
+
+    analysis_test(
+        name = name,
+        target = name + "/test",
+        impl = _test_execution_requirements_impl,
+    )
+
+def _test_execution_requirements_impl(env, target):
+    env.expect.that_target(target).provider(testing.ExecutionInfo).requirements().contains_at_least(
+        {"requires-network": ""},
+    )
+
 def _test_mac_requires_darwin_for_execution(name):
     util.helper_target(
         rule = native.platform,
@@ -223,6 +242,7 @@ def _test_mac_requires_darwin_for_execution(name):
         rule = java_test,
         name = name + "/test",
         srcs = [name + "/Test.java"],
+        execution_requirements = {"requires-network": ""},
         use_launcher = False,
         use_testrunner = 0,
     )
@@ -252,7 +272,10 @@ def _test_mac_requires_darwin_for_execution(name):
 
 def _test_mac_requires_darwin_for_execution_impl(env, target):
     env.expect.that_target(target).provider(testing.ExecutionInfo).requirements().contains_at_least(
-        {"requires-darwin": ""},
+        {
+            "requires-darwin": "",
+            "requires-network": "",
+        },
     )
 
 def _test_java_test_sets_securiry_manager_property_jdk17(name):
@@ -405,6 +428,7 @@ def java_test_tests(name):
             _test_java_test_propagates_direct_native_libraries,
             _test_coverage_uses_coverage_runner_for_main,
             _test_stamp_values,
+            _test_execution_requirements,
             _test_mac_requires_darwin_for_execution,
             _test_java_test_sets_securiry_manager_property_jdk17,
             _test_one_version_check_java_test,


### PR DESCRIPTION
Using tags for requirements affects every action that builds a test. Add a java_test attribute backed by testing.ExecutionInfo so callers can scope requirements such as network access to the runner.

Keep the automatic requires-darwin requirement and cover both direct requirements and merge behavior with analysis tests.